### PR TITLE
Update DataRecord.cpp

### DIFF
--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -143,6 +143,7 @@ DataRecord::DataRecord(Category* cat, int nID, unsigned long len, const unsigned
   {
     m_bFormatOK = true;
   }
+  m_nLength = len - nUnparsed;//If without this row, the left data records in the block will not be parsed. Added by Christine Tan.
 }
 
 DataRecord::~DataRecord()


### PR DESCRIPTION
Fixed the bug that the data records can not be parsed correctly: if there are more than one data records in a data block, the ones after the first data record will be ignored.
