### PR TITLE
Add recorded timestamp to output

### DIFF
--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -176,12 +176,13 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 	case CAsterixFormat::ETxt:
 		strNewResult = format("\n-------------------------\nData Record %d", m_nID);
 		strNewResult += format("\nLen: %ld", m_nLength);
+		strNewResult += format("\nTimestamp: %ld", m_nTimestamp);
 		break;
 	case CAsterixFormat::EJSON:
-		strNewResult = format("{\"CAT%03d\":{", m_pCategory->m_id);
+		strNewResult = format("{\"timestamp\":%ld,\"CAT%03d\":{", m_nTimestamp, m_pCategory->m_id);
 		break;
 	case CAsterixFormat::EJSONH:
-		strNewResult = format("{\"CAT%03d\":{\n", m_pCategory->m_id);
+		strNewResult = format("{\"timestamp\":%ld,\n\"CAT%03d\":{\n", m_nTimestamp, m_pCategory->m_id);
 		break;
 	case CAsterixFormat::EXML:
 		const int nXIDEFv = 1;

--- a/src/asterix/InputParser.cpp
+++ b/src/asterix/InputParser.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "InputParser.h"
-#include <time.h>
 
 InputParser::InputParser(AsterixDefinition* pDefinition)
 : m_pDefinition(pDefinition)
@@ -32,23 +31,17 @@ InputParser::InputParser(AsterixDefinition* pDefinition)
 /*
  * Parse data
  */
-AsterixData* InputParser::parsePacket(const unsigned char* m_pBuffer, unsigned int m_nBufferSize)
+AsterixData* InputParser::parsePacket(const unsigned char* m_pBuffer, unsigned int m_nBufferSize, unsigned long nTimestamp)
 {
   AsterixData* pAsterixData = new AsterixData();
   unsigned int m_nPos = 0;
   unsigned int m_nDataLength = 0;
   const unsigned char* m_pData = m_pBuffer; // internally used pointer to parsed data
-  time_t nTimestamp = 0;
 
   while(m_nPos < m_nBufferSize)
   {
     bool bOK = true;
     m_nDataLength = m_nBufferSize;
-
-    if (!nTimestamp)
-    {
-      time(&nTimestamp);
-    }
 
     while(bOK && m_nDataLength > 0)
     {
@@ -78,7 +71,7 @@ AsterixData* InputParser::parsePacket(const unsigned char* m_pBuffer, unsigned i
       m_nDataLength -= 3;
       dataLen -= 3;
 
-      DataBlock* db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, (unsigned long)nTimestamp);
+      DataBlock* db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp);
       m_pData += dataLen;
       m_nPos += dataLen;
       pAsterixData->m_lDataBlocks.push_back(db);

--- a/src/asterix/InputParser.h
+++ b/src/asterix/InputParser.h
@@ -31,7 +31,7 @@ class InputParser
 {
 public:
   InputParser(AsterixDefinition* pDefinition);
-  AsterixData* parsePacket(const unsigned char* m_pBuffer, unsigned int m_nBufferSize);
+  AsterixData* parsePacket(const unsigned char* m_pBuffer, unsigned int m_nBufferSize, unsigned long nTimestamp = 0);
 
   std::string printDefinition();
   bool filterOutItem(int cat, std::string item, const char* name);

--- a/src/asterix/asterixfinalsubformat.cxx
+++ b/src/asterix/asterixfinalsubformat.cxx
@@ -46,6 +46,10 @@ bool CAsterixFinalSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor,
       return false;
   }
 
+  unsigned long nTimestamp = (unsigned long) finalRecordHeader.m_nTimeMMSB << 16;
+  nTimestamp |= (unsigned long) finalRecordHeader.m_nTimeMSB << 8;
+  nTimestamp |= (unsigned long) finalRecordHeader.m_nTimeLSB;
+
   unsigned int neededLen = finalRecordHeader.m_nByteCountMSB;
   neededLen <<= 8;
   neededLen |= finalRecordHeader.m_nByteCountLSB;
@@ -79,7 +83,7 @@ bool CAsterixFinalSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor,
   if (Descriptor.m_pAsterixData)
     delete Descriptor.m_pAsterixData;
 
-  Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(pBuffer, neededLen);
+  Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(pBuffer, neededLen, nTimestamp);
 
   return true;
 }


### PR DESCRIPTION
- timestamp added to JSON and default output
- only implemented for final format so far

I used the existing unsigned long m_nTimestamp variable.
In final format, we only have the time of day (seconds since midnight \* 100). That's what I pass.

In PCAP, we have a UNIX timestamp (seconds and microseconds since epoch). I'm not sure what's the best to pass in that case.
