### PR TITLE
Skip DataBlock decoding when category is filtered

### DIFF
--- a/src/asterix/Category.cpp
+++ b/src/asterix/Category.cpp
@@ -25,6 +25,7 @@
 
 Category::Category(int id)
 : m_id(id)
+, m_bFiltered(false)
 {
 }
 
@@ -154,6 +155,9 @@ bool Category::filterOutItem(std::string item, const char* name)
 {
 	std::list<DataItemDescription*>::iterator it;
 	DataItemDescription* di = NULL;
+
+	// At least one item of category shall be printed when filter is applied
+	m_bFiltered = true;
 
 	for ( it=m_lDataItems.begin() ; it != m_lDataItems.end(); it++ )
 	{

--- a/src/asterix/Category.h
+++ b/src/asterix/Category.h
@@ -38,6 +38,7 @@ public:
   ~Category();
 
   unsigned int m_id;
+  bool m_bFiltered; //! at least one item of category shall be printed when filter is applied
 
   std::string m_strName;
   std::string m_strVer;

--- a/src/asterix/DataBlock.cpp
+++ b/src/asterix/DataBlock.cpp
@@ -25,6 +25,8 @@
 #include "Utils.h"
 #include "asterixformat.hxx"
 
+extern bool gFiltering;
+
 DataBlock::DataBlock(Category* cat, unsigned long len, const unsigned char* data, unsigned long nTimestamp)
 : m_pCategory(cat)
 , m_nLength(len)
@@ -34,6 +36,12 @@ DataBlock::DataBlock(Category* cat, unsigned long len, const unsigned char* data
   const unsigned char* m_pItemDataStart = data;
   long nUnparsed = len;
   int counter=1;
+
+  if (gFiltering && !m_pCategory->m_bFiltered)
+  {
+    m_bFormatOK = true;
+    return;
+  }
 
   while(nUnparsed > 0)
   {
@@ -79,6 +87,11 @@ DataBlock::~DataBlock()
 bool DataBlock::getText(std::string& strResult, const unsigned int formatType)
 {
 	std::string strHeader;
+
+	if (gFiltering && !m_pCategory->m_bFiltered)
+	{
+		return false;
+	}
 
 	switch(formatType)
 {


### PR DESCRIPTION
When a filter is applied, a data block shall be decoded only
if at least one item of the corresponding category shall be
displayed.
This improves the performances when filtering out some categories.
