### PR TITLE
Set recorded timestamp to milliseconds

### DIFF
--- a/src/asterix/asterixfinalsubformat.cxx
+++ b/src/asterix/asterixfinalsubformat.cxx
@@ -49,6 +49,8 @@ bool CAsterixFinalSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor,
   unsigned long nTimestamp = (unsigned long) finalRecordHeader.m_nTimeMMSB << 16;
   nTimestamp |= (unsigned long) finalRecordHeader.m_nTimeMSB << 8;
   nTimestamp |= (unsigned long) finalRecordHeader.m_nTimeLSB;
+  // convert timestamp to milliseconds (resolution is 10ms in final format)
+  nTimestamp = nTimestamp * 10;
 
   unsigned int neededLen = finalRecordHeader.m_nByteCountMSB;
   neededLen <<= 8;

--- a/src/asterix/asterixpcapsubformat.cxx
+++ b/src/asterix/asterixpcapsubformat.cxx
@@ -101,6 +101,9 @@ bool CAsterixPcapSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, 
 		return false;
 	}
 
+	// Save PCAP packet timestamp (keep milliseconds since midnight)
+	unsigned long nTimestamp = (m_ePcapRecHeader.ts_sec % 86400) * 1000 + m_ePcapRecHeader.ts_usec / 1000;
+
 	if (gSynchronous)
 	{ // In synchronous mode make delays between packets to simulate real tempo
 		struct timeval currTime;
@@ -269,7 +272,7 @@ bool CAsterixPcapSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, 
 				break;
 
 			// Parse ASTERIX data
-			AsterixData* m_ptmpAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, byteCount-6);
+			AsterixData* m_ptmpAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, byteCount-6, nTimestamp);
 
 			if (Descriptor.m_pAsterixData == NULL)
 			{
@@ -286,7 +289,7 @@ bool CAsterixPcapSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, 
 	}
 	else
 	{
-		Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, m_nDataLength);
+		Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, m_nDataLength, nTimestamp);
 	}
 
 	delete pPacketBuffer;


### PR DESCRIPTION
- PCAP timestamp added
- For compatibility between PCAP and final format,
  milliseconds since midnight are used for timestamp
