### PR TITLE
Improve description of not found filtering item, added protection against malformed filters

### DIFF
--- a/src/main/asterix.cpp
+++ b/src/main/asterix.cpp
@@ -355,43 +355,53 @@ int main(int argc, const char *argv[])
     		while( fgets(line,1024,ff) )
     		{
 
-				int cat = 0;
-				char item[128];
-				char name[128];
+			int cat = 0;
+			char item[128] = "";
+			char name[128] = "";
 
-				// skip commented lines
-				if (line[0] == '#' || strlen(line)<=0)
-					continue;
+			// skip commented lines
+			if (line[0] == '#' || strlen(line)<=0)
+				continue;
 
-				char *p = strtok(line, ":");
-				int ret = 0;
-				while(p)
-				{
-					if (sscanf(p, "CAT%03d", &cat) != 1)
-						break;
-					p = strtok(NULL, ":");
-					if (sscanf(p, "I%128s", item) != 1)
-						break;
-					p = strtok(NULL, ":");
-					if (sscanf(p, "%128s", name) != 1)
-						break;
-					ret = 1;
+			char *p = strtok(line, ":");
+			int ret = 0;
+			while(p)
+			{
+				if (sscanf(p, "CAT%03d", &cat) != 1)
 					break;
-				}
-
-				if (ret == 0)
+				p = strtok(NULL, ":");
+				if ( NULL == p )
 				{
-					std::cerr << "Warning: Wrong Filter format. Shall be: \"CATxxx:Ixxx:NAME  DESCRIPTION\" or start with \"#\" for comment . It is: "+std::string(line)  << std::endl;
+					std::cerr << "Warning: Wrong Filter format. Shall be: \"CATxxx:Ixxx:NAME  DESCRIPTION\" or start with \"#\" for comment . It is: "+std::string(line) << std::endl;
 					exit(3);
 				}
-
-				if (!desc->filterOutItem(cat, std::string(item), name))
+				if (sscanf(p, "I%128s", item) != 1)
+					break;
+				p = strtok(NULL, ":");
+				if ( NULL == p )
 				{
-					std::cerr << "Warning: Filtering item not found: "+std::string(line)  << std::endl;
+					std::cerr << "Warning: Wrong Filter format. Shall be: \"CATxxx:Ixxx:NAME  DESCRIPTION\" or start with \"#\" for comment . It is: "+std::string(line) << std::endl;
+					exit(3);
 				}
-    		}
-    		fclose(ff);
-    	}
+				if (sscanf(p, "%128s", name) != 1)
+					break;
+				ret = 1;
+				break;
+			}
+
+			if (ret == 0)
+			{
+				std::cerr << "Warning: Wrong Filter format. Shall be: \"CATxxx:Ixxx:NAME  DESCRIPTION\" or start with \"#\" for comment . It is: "+std::string(line) << std::endl;
+				exit(3);
+			}
+
+			if (!desc->filterOutItem(cat, std::string(item), name))
+			{
+				std::cerr << "Warning: Filtering item not found: "+std::string(line)+":"+std::string(item)+":"+std::string(name)  << std::endl;
+			}
+		}
+		fclose(ff);
+	}
 
     	if (bListDefinitions)
     	{ // Parse definitions file and print all items


### PR DESCRIPTION
Current description doesn't describe missing items, so it is very
difficult to search and fix them. Now, the whole line is print.

Also, if a filter line is malformed (doesn't have ':' in it) old
implementation would segfault.

Some tabs where messed, fixed also in the commit.