### PR TITLE
Subscribe to more than one multicast group for input

### DIFF
--- a/README
+++ b/README
@@ -93,6 +93,8 @@ Data source:
    					For example: -f filename.pcap
    -i m:i:p[:s]		Multicast IP address:Interface address:Port[:Source address].
    					For example: 232.1.1.12:10.17.58.37:21112:10.17.22.23
+                        More than one multicast group could be defined, use @ as separator.
+                                        For example: 232.1.1.13:10.17.58.37:21112:10.17.22.23@232.1.1.14:10.17.58.37:21112:10.17.22.23
 
 WIRESHARK PLUGIN
 =================

--- a/src/engine/converterengine.cxx
+++ b/src/engine/converterengine.cxx
@@ -43,6 +43,10 @@ bool CConverterEngine::Initialize(const char *inputChannel, const char *outputCh
     const char *inputFormat           = inputDescriptor.GetNext();
     const char *inputFormatDescriptor = inputDescriptor.GetNext();
 
+    LOGDEBUG(1, "inputDevice(%s)", inputDevice);
+    LOGDEBUG(1, "inputDeviceDescriptor(%s)", inputDeviceDescriptor);
+    LOGDEBUG(1, "inputFormatDescriptor(%s)", inputFormatDescriptor);
+
     // Check input channel parameters consistency
     if ((inputDevice == NULL) || (inputDeviceDescriptor == NULL) || (inputFormat == NULL))
     {

--- a/src/engine/devicefactory.cxx
+++ b/src/engine/devicefactory.cxx
@@ -74,7 +74,7 @@ bool CDeviceFactory::CreateDevice(const char* deviceName, const char* deviceDesc
     }
     
     // Initialize descriptor
-    CDescriptor descriptor(deviceDescriptor, ":");
+    CDescriptor descriptor(deviceDescriptor, "@");
     
     // Search for specified device and create it
     if (strcasecmp(deviceName, "tcp") == 0)

--- a/src/engine/udpdevice.cxx
+++ b/src/engine/udpdevice.cxx
@@ -184,7 +184,7 @@ bool CUdpDevice::Read(void *data, size_t* len)
     struct sockaddr_in clientAddr;
     socklen_t clientLen = sizeof(clientAddr);
 
-    for(unsigned int i; i<_socketDesc.size() || _countToRead>0; i++)
+    for(unsigned int i=0; i<_socketDesc.size() && _countToRead>0; i++)
     {
 	if ( FD_ISSET(_socketDesc[i], &_descToRead) )
 	{

--- a/src/engine/udpdevice.cxx
+++ b/src/engine/udpdevice.cxx
@@ -36,74 +36,131 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <iostream>
 
 // Local includes
 #include "asterix.h"
 #include "udpdevice.hxx"
+#include "descriptor.hxx"
 
 
 
 CUdpDevice::CUdpDevice(CDescriptor &descriptor)
 {
-    const char *mcastAddress     = descriptor.GetFirst();
-    const char *interfaceAddress = descriptor.GetNext();
-    const char *port             = descriptor.GetNext();
-    const char *sourceAddress 	 = descriptor.GetNext();
-    const char *server           = descriptor.GetNext();
     int portNo = 0;
     bool isServer = false;
+    const char *element;
+    const char *mcastAddress;
+    const char *interfaceAddress;
+    const char *port;
+    const char *sourceAddress;
+    const char *server;
+    _countToRead = 0;
+    _maxValSocketDesc = 0;
 
-    ASSERT(mcastAddress && interfaceAddress && port && server);
+    element = descriptor.GetFirst();
 
-    // Mcast address argument
-    if (strlen(mcastAddress) == 0)
-    {
-        LOGINFO(gVerbose, "Mcast address not specified\n");
+    while (true) {
+	if (NULL == element)
+	{
+	    for(unsigned int i=0; i<_socketDesc.size(); i++)
+	    {
+		if (_socketDesc[i] > _maxValSocketDesc)
+		{
+		    _maxValSocketDesc = _socketDesc[i];
+		}
+	    }
+	    _maxValSocketDesc++;
+	    return;
+	}
+	int cntr=0;
+	int indx=0;
+	std::string str = element;
+	while((indx=str.find(':', indx+1)) >= 0)
+	{
+	    cntr++;
+	}
+	if (cntr < 2 || cntr > 3)
+	{
+	    LOGERROR(1, "Error: Wrong input address format (shall be: mcastaddress:ipaddress:port[:srcaddress]\n");
+	    LOGERROR(1, "mcast description(%s)\n", element);
+	    exit (3);
+	}
+
+	CDescriptor flow(element, ":");
+	mcastAddress = flow.GetFirst();
+	interfaceAddress = flow.GetNext();
+	port             = flow.GetNext();
+	sourceAddress    = flow.GetNext();
+	server           = "S"; //flow.GetNext();
+
+	LOGINFO(gVerbose, "mcastAddress(%s)\n", mcastAddress);
+	LOGINFO(gVerbose, "interfaceAddress(%s)\n", interfaceAddress);
+	LOGINFO(gVerbose, "port(%s)\n", port);
+	LOGINFO(gVerbose, "sourceAddress(%s)\n", sourceAddress);
+	LOGINFO(gVerbose, "server(%s)\n", server);
+
+	/*
+	if ((0 == strlen(mcastAddress)) || (0 == strlen(port)) || (0 == strlen(interfaceAddress))) {
+	    std::cerr << "Error: Wrong input address format  (shall be: mcastaddress:ipaddress:port[:srcaddress]" << std::endl;
+	    exit (3);
+	}
+	*/
+
+	ASSERT(mcastAddress && interfaceAddress && port && server);
+	element = descriptor.GetNext();
+
+	// Mcast address argument
+	if (strlen(mcastAddress) == 0)
+	{
+	    LOGINFO(gVerbose, "Mcast address not specified\n");
+	}
+
+	// Interface address argument may be null.
+	// In that case INADDR_ANY will be used.
+	if (strlen(interfaceAddress) == 0)
+	{
+	    LOGINFO(gVerbose, "INADDR_ANY used as interface\n");
+	}
+
+	// Mcast port argument
+	if (port == NULL)
+	{
+	    LOGWARNING(gVerbose, "Mcast port not specified (%d by default)\n", portNo);
+	}
+	else
+	{
+	    portNo = atoi(port);
+	}
+
+	// Server argument
+	if (strlen(server) == 0)
+	{
+	    LOGWARNING(1, "Server flag not specified (%d by default)\n", isServer);
+	}
+	else
+	{
+	    if (toupper(*server) == 'S')
+	    {
+		isServer = true;
+	    }
+	}
+
+	// Call default initialization
+	Init(mcastAddress, interfaceAddress, sourceAddress, portNo, isServer);
     }
 
-    // Interface address argument may be null.
-    // In that case INADDR_ANY will be used.
-    if (strlen(interfaceAddress) == 0)
-    {
-        LOGINFO(gVerbose, "INADDR_ANY used as interface\n");
-    }
-
-    // Mcast port argument
-    if (port == NULL)
-    {
-        LOGWARNING(gVerbose, "Mcast port not specified (%d by default)\n", portNo);
-    }
-    else
-    {
-        portNo = atoi(port);
-    }
-
-    // Server argument
-    if (strlen(server) == 0)
-    {
-        LOGWARNING(1, "Server flag not specified (%d by default)\n", isServer);
-    }
-    else
-    {
-        if (toupper(*server) == 'S')
-        {
-            isServer = true;
-        }
-    }
-
-
-    // Call default initialization
-    Init(mcastAddress, interfaceAddress, sourceAddress, portNo, isServer);
 }
 
 
 
 CUdpDevice::~CUdpDevice()
 {
-    if (_socketDesc >= 0)
+    for(unsigned int i=0; i<_socketDesc.size(); i++)
     {
-        close(_socketDesc);
+        close(_socketDesc[i]);
     }
+    _countToRead = 0;
 }
 
 
@@ -126,24 +183,34 @@ bool CUdpDevice::Read(void *data, size_t* len)
     // Get the message (blocking)
     struct sockaddr_in clientAddr;
     socklen_t clientLen = sizeof(clientAddr);
-    ssize_t lenread = recvfrom(_socketDesc, data, *len, MSG_NOSIGNAL, (struct sockaddr *) &clientAddr, &clientLen);
-    if (lenread < 0)
-    {
-        LOGERROR(1, "Error reading from %s on address %s.\n",
-           inet_ntoa(clientAddr.sin_addr),
-           inet_ntoa(_mcastAddr.sin_addr));
 
-        CountReadError();
-        return false;
+    for(unsigned int i; i<_socketDesc.size() || _countToRead>0; i++)
+    {
+	if ( FD_ISSET(_socketDesc[i], &_descToRead) )
+	{
+	    // _socketDesc is going to be read, clear bits
+	    _countToRead--;
+	    FD_CLR(_socketDesc[i], &_descToRead);
+	    ssize_t lenread = recvfrom(_socketDesc[i], data, *len, MSG_NOSIGNAL, (struct sockaddr *) &clientAddr, &clientLen);
+	    if (lenread < 0)
+	    {
+		LOGERROR(1, "Error reading from %s on address %s.\n",
+		     inet_ntoa(clientAddr.sin_addr),
+		    inet_ntoa(_mcastAddr.sin_addr));
+		    CountReadError();
+		return false;
+	    }
+
+	    *len = lenread;
+
+	    LOGDEBUG(ZONE_UDPDEVICE, "Read message from %s on address %s.\n",
+		inet_ntoa(clientAddr.sin_addr),
+		inet_ntoa(_mcastAddr.sin_addr));
+
+	    ResetReadErrors(true);
+	}
     }
 
-    *len = lenread;
-
-    LOGDEBUG(ZONE_UDPDEVICE, "Read message from %s on address %s.\n",
-           inet_ntoa(clientAddr.sin_addr),
-           inet_ntoa(_mcastAddr.sin_addr));
-
-    ResetReadErrors(true);
     return true;
 }
 
@@ -162,7 +229,7 @@ bool CUdpDevice::Write(const void *data, size_t len)
     // Set the server address
 
     // Write the message (blocking)
-    if (sendto(_socketDesc, data, len, MSG_NOSIGNAL, (struct sockaddr*) &_mcastAddr, sizeof(_mcastAddr)) < 0)
+    if (sendto(_socketDesc[0], data, len, MSG_NOSIGNAL, (struct sockaddr*) &_mcastAddr, sizeof(_mcastAddr)) < 0)
     {
         LOGERROR(1, "Error %d writing to %s.\n",
             errno, inet_ntoa(_mcastAddr.sin_addr));
@@ -189,11 +256,19 @@ bool CUdpDevice::Select(const unsigned int secondsToWait)
         return false;
     }
 
+    // check if there is some data waiting to be read
+    if (_countToRead>0)
+    {
+	return (_countToRead > 0);
+    }
+
     // Configure 'set' of single class file descriptor
-    fd_set descToRead;
     int selectVal;
-    FD_ZERO(&descToRead);
-    FD_SET(_socketDesc, &descToRead);
+    FD_ZERO(&_descToRead);
+    for(unsigned int i=0; i<_socketDesc.size(); i++)
+    {
+	FD_SET(_socketDesc[i], &_descToRead);
+    }
 
     if (secondsToWait)
     {
@@ -202,20 +277,22 @@ bool CUdpDevice::Select(const unsigned int secondsToWait)
         timeout.tv_sec  = secondsToWait;
         timeout.tv_usec = 0;
 
-        selectVal = select(_socketDesc + 1, &descToRead,  NULL, NULL, &timeout);
+        selectVal = select(_maxValSocketDesc, &_descToRead,  NULL, NULL, &timeout);
     }
     else
     {
         // secondsToWait is zero => Wait indefinitely
-        selectVal = select(_socketDesc + 1, &descToRead,  NULL, NULL, NULL);
+        selectVal = select(_maxValSocketDesc, &_descToRead,  NULL, NULL, NULL);
     }
 
-    return (selectVal == 1);
+    _countToRead = selectVal;
+
+    return (selectVal > 0);
 }
 
 
 
-bool CUdpDevice::InitServer()
+bool CUdpDevice::InitServer(int socketDesc)
 {
     struct sockaddr_in serverAddr;
 
@@ -233,15 +310,15 @@ bool CUdpDevice::InitServer()
     }
     serverAddr.sin_port = htons(_port);
 
-    if (bind(_socketDesc, (struct sockaddr*) &serverAddr, sizeof(serverAddr)) < 0)
+    if (bind(socketDesc, (struct sockaddr*) &serverAddr, sizeof(serverAddr)) < 0)
     {
         if (IN_MULTICAST(ntohl(_mcastAddr.sin_addr.s_addr)))
         { // If failed to bind multicast address (note that it will always fail on Windows) then try with ANY port
             serverAddr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-            if (bind(_socketDesc, (struct sockaddr*) &serverAddr, sizeof(serverAddr)) < 0)
+            if (bind(socketDesc, (struct sockaddr*) &serverAddr, sizeof(serverAddr)) < 0)
             {
-                LOGERROR(1, "Cannot bind multicast address and port number %d\n", _port);
+		LOGERROR(1, "Cannot bind multicast address %s and port number %d\n", inet_ntoa(_mcastAddr.sin_addr), _port);
                 return false;
             }
         }
@@ -262,7 +339,7 @@ bool CUdpDevice::InitServer()
  	       mreq.imr_interface.s_addr = _interfaceAddr.s_addr;
  	       mreq.imr_sourceaddr.s_addr = _sourceAddr.s_addr;// source address
 
- 	       if (setsockopt(_socketDesc, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP, (void*) &mreq, sizeof(mreq)) < 0)
+		if (setsockopt(socketDesc, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP, (void*) &mreq, sizeof(mreq)) < 0)
  	       {
  	          LOGERROR(1, "Cannot join multicast address %s src: %s\n", inet_ntoa(_mcastAddr.sin_addr), inet_ntoa(_sourceAddr));
  	          return false;
@@ -279,7 +356,7 @@ bool CUdpDevice::InitServer()
 			mreq.imr_multiaddr.s_addr = _mcastAddr.sin_addr.s_addr;
 			mreq.imr_interface.s_addr = _interfaceAddr.s_addr;
 
-			if (setsockopt(_socketDesc, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void*) &mreq, sizeof(mreq)) < 0)
+			if (setsockopt(socketDesc, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void*) &mreq, sizeof(mreq)) < 0)
 			{
 			  LOGERROR(1, "Cannot join multicast address %s\n", inet_ntoa(_mcastAddr.sin_addr));
 			  return false;
@@ -290,12 +367,13 @@ bool CUdpDevice::InitServer()
 			}
     	}
     }
+
     return true;
 }
 
 
 
-bool CUdpDevice::InitClient()
+bool CUdpDevice::InitClient(int socketDesc)
 {
     struct sockaddr_in clientAddr;
 
@@ -304,7 +382,7 @@ bool CUdpDevice::InitClient()
     clientAddr.sin_addr.s_addr = htonl(INADDR_ANY);
     clientAddr.sin_port = htons(0);
 
-    if (bind(_socketDesc, (struct sockaddr*) &clientAddr, sizeof(clientAddr)) < 0)
+    if (bind(socketDesc, (struct sockaddr*) &clientAddr, sizeof(clientAddr)) < 0)
     {
         LOGERROR(1, "Cannot bind \n");
         return false;
@@ -314,12 +392,13 @@ bool CUdpDevice::InitClient()
     {
         unsigned char ttl = 1;  // send multicast on subnet only (ttl = 1)
         // Set ttl on the socket
-        if (setsockopt(_socketDesc, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
+        if (setsockopt(socketDesc, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
         {
            LOGERROR(1, "Cannot set ttl = %d\n", ttl);
            return false;
         }
     }
+
     return true;
 }
 
@@ -329,11 +408,14 @@ void CUdpDevice::Init(const char *mcastAddress, const char *interfaceAddress, co
 {
     struct hostent *host;
     u_int yes=1;
+    int socketDesc;
 
     _opened = false;
-    _socketDesc = -1;
+    //_socketDesc = -1;
     _server = server;
     _port   = port;
+    //_countToRead = 0;
+
 
     // 1. Global initialization
 
@@ -395,15 +477,15 @@ void CUdpDevice::Init(const char *mcastAddress, const char *interfaceAddress, co
     }
 
     // 1.3 Socket
-    _socketDesc = socket(AF_INET, SOCK_DGRAM, 0);
-    if (_socketDesc < 0)
+    socketDesc = socket(AF_INET, SOCK_DGRAM, 0);
+    if (socketDesc < 0)
     {
         LOGERROR(1, "Cannot open socket\n");
         return;
     }
 
     // Allow multiple sockets to use the same PORT number
-    if (setsockopt(_socketDesc, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) < 0)
+    if (setsockopt(socketDesc, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) < 0)
     {
         LOGERROR(1, "Cannot reuse socket address\n");
         return;
@@ -412,7 +494,7 @@ void CUdpDevice::Init(const char *mcastAddress, const char *interfaceAddress, co
     // 2. Client/server dependant initialization
     if (_server)
     {
-        if (!InitServer())
+        if (!InitServer(socketDesc))
         {
             LOGERROR(1, "Server not initialized\n");
             return;
@@ -420,13 +502,14 @@ void CUdpDevice::Init(const char *mcastAddress, const char *interfaceAddress, co
     }
     else
     {
-        if (!InitClient())
+        if (!InitClient(socketDesc))
         {
             LOGERROR(1, "Client not initialized\n");
             return;
         }
     }
 
+    _socketDesc.push_back(socketDesc);
     _opened = true;
 
 }

--- a/src/engine/udpdevice.cxx
+++ b/src/engine/udpdevice.cxx
@@ -172,10 +172,11 @@ bool CUdpDevice::Read(void *data, size_t len)
 
 bool CUdpDevice::Read(void *data, size_t* len)
 {
+
     // Check if interface was set-up correctly (server)
     if ((!_opened) || (!_server))
     {
-        LOGERROR(1, "Cannot write due to not properly initialized interface.\n");
+        LOGERROR(1, "Cannot read due to not properly initialized interface.\n");
         CountReadError();
         return false;
     }
@@ -188,8 +189,8 @@ bool CUdpDevice::Read(void *data, size_t* len)
     {
 	if ( FD_ISSET(_socketDesc[i], &_descToRead) )
 	{
-	    // _socketDesc is going to be read, clear bits
 	    _countToRead--;
+	    // _socketDesc is going to be read, clear bits
 	    FD_CLR(_socketDesc[i], &_descToRead);
 	    ssize_t lenread = recvfrom(_socketDesc[i], data, *len, MSG_NOSIGNAL, (struct sockaddr *) &clientAddr, &clientLen);
 	    if (lenread < 0)
@@ -207,10 +208,11 @@ bool CUdpDevice::Read(void *data, size_t* len)
 		inet_ntoa(clientAddr.sin_addr),
 		inet_ntoa(_mcastAddr.sin_addr));
 
+
 	    ResetReadErrors(true);
+	    return true;
 	}
     }
-
     return true;
 }
 

--- a/src/engine/udpdevice.hxx
+++ b/src/engine/udpdevice.hxx
@@ -27,6 +27,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <vector>
 
 #include "basedevice.hxx"
 #include "descriptor.hxx"
@@ -58,11 +59,14 @@ private:
     struct in_addr     _interfaceAddr;
     struct in_addr     _sourceAddr;
     int                _port;
-    int                _socketDesc;
+    std::vector<int>   _socketDesc;
+    fd_set             _descToRead;
+    int                _countToRead;
+    int                _maxValSocketDesc;
 
 private:
-    bool InitServer();
-    bool InitClient();
+    bool InitServer(int socketDesc);
+    bool InitClient(int socketDesc);
 
 public:
 

--- a/src/main/asterix.cpp
+++ b/src/main/asterix.cpp
@@ -57,20 +57,20 @@ static void show_usage(std::string name)
 
 	std::cerr << "\n\nReads and parses ASTERIX data from stdin, file or network multicast stream\nand prints it in textual presentation on standard output.\n\n"
 			  << "Usage:\n"
-			  <<  name << " [-h] [-v] [-L] [-o] [-s] [-P|-O|-R|-F|-H] [-l|-x|-j|-jh] [-d filename] [-LF filename] -f filename|-i mcastaddress:ipaddress:port[:srcaddress]"
+			  <<  name << " [-h] [-v] [-L] [-o] [-s] [-P|-O|-R|-F|-H] [-l|-x|-j|-jh] [-d filename] [-LF filename] -f filename|-i (mcastaddress:ipaddress:port[:srcaddress]@)+"
 			  << "\n\nOptions:"
-			  << "\n\t-h,--help\tShow this help message"
-			  << "\n\t-v,--verbose\tShow more information during program execution"
+			  << "\n\t-h,--help\tShow this help message."
+			  << "\n\t-v,--verbose\tShow more information during program execution."
 			  << "\n\t-d,--def\tXML protocol definitions filenames are listed in specified filename. By default are listed in config/asterix.ini"
 			  << "\n\t-L,--list\tList all configured ASTERIX items. Mark which items are filtered."
-			  << "\n\t-LF,--filter\tPrintout only items listed in configured file"
+			  << "\n\t-LF,--filter\tPrintout only items listed in configured file."
 			  << "\n\t-o,--loop\tLoop the input file. Only relevant when file is data source."
 			  << "\n\t-s,--sync\tOutput will be printed synchronously with input file (with time delays between packets). This parameter is used only if input is from file."
 			  << "\n\nInput format"
 			  << "\n------------"
-			  << "\n\t-P,--pcap\tInput is from PCAP file"
-			  << "\n\t-R,--oradispcap\tInput is from PCAP file and Asterix packet is encapsulated in ORADIS packet"
-			  << "\n\t-O,--oradis\tAsterix packet is encapsulated in ORADIS packet"
+			  << "\n\t-P,--pcap\tInput is from PCAP file."
+			  << "\n\t-R,--oradispcap\tInput is from PCAP file and Asterix packet is encapsulated in ORADIS packet."
+			  << "\n\t-O,--oradis\tAsterix packet is encapsulated in ORADIS packet."
 			  << "\n\t-F,--final\tAsterix packet is encapsulated in FINAL packet."
 			  << "\n\t-H,--hdlc\tAsterix packet is encapsulated in HDLC packet."
 			  << "\n\nOutput format"
@@ -82,7 +82,7 @@ static void show_usage(std::string name)
 			  << "\n\nData source"
 			  << "\n------------"
 			  << "\n\t-f filename\tFile generated from libpcap (tcpdump or Wireshark) or file in FINAL or HDLC format.\n\t\t\tFor example: -f filename.pcap"
-			  << "\n\t-i m:i:p[:s]\tMulticast IP address:Interface address:Port[:Source address].\n\t\t\tFor example: 232.1.1.12:10.17.58.37:21112:10.17.22.23"
+			  << "\n\t-i m:i:p[:s]\tMulticast IP address:Interface address:Port[:Source address].\n\t\t\tFor example: 232.1.1.12:10.17.58.37:21112:10.17.22.23\n\t\t\tMore than one multicast group could be defined, use @ as separator.\n\t\t\tFor example: 232.1.1.13:10.17.58.37:21112:10.17.22.23@232.1.1.14:10.17.58.37:21112:10.17.22.23"
 			  << std::endl;
 }
 
@@ -272,6 +272,7 @@ int main(int argc, const char *argv[])
 
 	// Create input string
 	std::string strInput = "std 0 ";
+	std::string strInputFixed = "";
 	if (!strFileInput.empty() && !strIPInput.empty())
 	{
 		strInput = "std 0 ASTERIX_RAW";
@@ -291,6 +292,7 @@ int main(int argc, const char *argv[])
 	}
 	else if (!strIPInput.empty())
 	{
+/*
 		// count ':'
 		int cntr=0;
 		int indx=0;
@@ -307,6 +309,8 @@ int main(int argc, const char *argv[])
 			std::cerr << "Error: Wrong input address format  (shall be: mcastaddress:ipaddress:port[:srcaddress]" << std::endl;
 			exit (3);
 		}
+*/
+		strInput = "udp " + strIPInput + " "; // + ":S ";
 	}
 
 	strInput += strInputFormat;


### PR DESCRIPTION
Radar data distribution in our organisation is done using one multicast group for each surveillance sensor. To be able to listen to more than one sensor, this modification was needed. 

The same syntax is used with the "-i" modifier, but more than one group could be entered by using the "@" as separator between groups definitions. Documentation with the -h switch has been updated with an example.

Code changes were kept to a minimum, mainly modifing udpdevice code. There is only one inputchannel defined, but now it can manage more subscriptions. Verification code of -i parameter syntax was moved to udpdevice. Opinions are welcomed!