### PR TITLE
Added hex dump of packets before asterix decoding in DEBUG mode

### DIFF
--- a/src/asterix/InputParser.cpp
+++ b/src/asterix/InputParser.cpp
@@ -48,7 +48,13 @@ AsterixData* InputParser::parsePacket(const unsigned char* m_pBuffer, unsigned i
       unsigned char nCategory = *m_pData;
       m_pData ++; m_nPos ++;
       unsigned short dataLen = *m_pData; // length
+#ifdef _DEBUG
+      unsigned char nDataLen1 = *m_pData;
+#endif
       m_pData ++; m_nPos ++;
+#ifdef _DEBUG
+      unsigned char nDataLen2 = *m_pData;
+#endif
       dataLen <<= 8;
       dataLen |= *m_pData;
       m_pData ++; m_nPos ++;
@@ -70,7 +76,23 @@ AsterixData* InputParser::parsePacket(const unsigned char* m_pBuffer, unsigned i
 
       m_nDataLength -= 3;
       dataLen -= 3;
+#ifdef _DEBUG
+      std::stringstream buffer;
+      buffer << std::hex << std::setfill('0');
+      buffer << std::setw(2) << std::uppercase << static_cast<unsigned>(nCategory) << " ";
+      buffer << std::hex << std::setfill('0');
+      buffer << std::setw(2) << std::uppercase << static_cast<unsigned>(nDataLen1) << " ";
+      buffer << std::hex << std::setfill('0');
+      buffer << std::setw(2) << std::uppercase << static_cast<unsigned>(nDataLen2) << " ";
 
+      for (int i = 0; i < dataLen; i++) {
+        buffer << std::hex << std::setfill('0');
+        buffer << std::setw(2) << std::uppercase << static_cast<unsigned>(m_pData[i]) << " ";
+      }
+      std::string hexString = buffer.str();
+      hexString.erase(hexString.size() - 1);
+      LOGDEBUG(1, "[%s]\n", hexString.c_str());
+#endif
       DataBlock* db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp);
       m_pData += dataLen;
       m_nPos += dataLen;

--- a/src/asterix/InputParser.h
+++ b/src/asterix/InputParser.h
@@ -23,7 +23,11 @@
 
 #ifndef INPUTPARSER_H_
 #define INPUTPARSER_H_
-
+#include <ios>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include "asterix.h"
 #include "AsterixDefinition.h"
 #include "AsterixData.h"
 

--- a/src/engine/tcpdevice.cxx
+++ b/src/engine/tcpdevice.cxx
@@ -229,8 +229,9 @@ bool CTcpDevice::Read(void *data, size_t len)
 #endif
     
     
-    LOGDEBUG(ZONE_TCPDEVICE, "Read message from socket %d.\n", 
-           socketToRecv);
+    LOGDEBUG(ZONE_TCPDEVICE, "Read message from socket %d with length %d.\n",
+           socketToRecv,
+           bytesReceived);
 
     ResetReadErrors(true);   
     return true;

--- a/src/engine/udpdevice.cxx
+++ b/src/engine/udpdevice.cxx
@@ -204,9 +204,10 @@ bool CUdpDevice::Read(void *data, size_t* len)
 
 	    *len = lenread;
 
-	    LOGDEBUG(ZONE_UDPDEVICE, "Read message from %s on address %s.\n",
+	    LOGDEBUG(ZONE_UDPDEVICE, "Read message from %s on address %s with length %zu.\n",
 		inet_ntoa(clientAddr.sin_addr),
-		inet_ntoa(_mcastAddr.sin_addr));
+		inet_ntoa(_mcastAddr.sin_addr),
+		lenread);
 
 
 	    ResetReadErrors(true);


### PR DESCRIPTION
When debuging some errors with asterix definitions, I realise that there was no option to dump packets before entering the asterix decoding class. With this patch, when compiled with the DEBUG flag, there is more information dumped.

Maybe one day we could have something like this:

```
048/040 measured position in polar coordinates
    [46 D1] rho(70.81640625)
    [DB 90] theta(308.75976563)
48/070 mode-3/A code in octal representation
    [29 4B] v(0) g(0) l(1) sp0(0) mode3a(4513) 
048/090 flight level in binary representation
    [05 C8] v(0) g(0) flight_level(370.00) 
```