### PR TITLE
BDS sign fix and BitShortName unification

### DIFF
--- a/install/config/asterix_bds.xml
+++ b/install/config/asterix_bds.xml
@@ -102,30 +102,18 @@
 					<BitsShortName>ROLL_STATUS</BitsShortName>
 					<BitsName>Roll Angle Status</BitsName>
 				</Bits>
-				<Bits bit="55">
-					<BitsShortName>ROLL_SIGN_DIR</BitsShortName>
-					<BitsName>Roll Angle Direction</BitsName>
-                    <BitsValue val="0">Right wing down</BitsValue>
-                    <BitsValue val="1">Left wing down</BitsValue>
-				</Bits>
-				<Bits from="54" to="46" encode="signed">
+				<Bits from="55" to="46" encode="signed">
 					<BitsShortName>ROLL_ANGLE</BitsShortName>
-					<BitsName>Roll angle</BitsName>
+					<BitsName>Roll Angle</BitsName>
                     <BitsUnit scale="0.17578125">deg</BitsUnit>
 				</Bits>
 				<Bits bit="45">
 					<BitsShortName>TRUE_TRACK_STATUS</BitsShortName>
 					<BitsName>True Track Angle Status</BitsName>
 				</Bits>
-				<Bits bit="44">
-					<BitsShortName>TRUE_TRACK_ANGLE_DIR</BitsShortName>
-					<BitsName>True Track Angle Direction</BitsName>
-                    <BitsValue val="0">East</BitsValue>
-                    <BitsValue val="1">West</BitsValue>
-				</Bits>
-				<Bits from="43" to="34" encode="signed">
+				<Bits from="44" to="34" encode="signed">
 					<BitsShortName>TRU_TRACK_ANGLE</BitsShortName>
-					<BitsName>True track angle</BitsName>
+					<BitsName>True Track Angle</BitsName>
                     <BitsUnit scale="0.17578125">deg</BitsUnit>
 				</Bits>
 				<Bits bit="33">
@@ -141,15 +129,9 @@
 					<BitsShortName>TRACK_ANGLE_RATE_STATUS</BitsShortName>
 					<BitsName>Track Angle Rate Status</BitsName>
 				</Bits>
-				<Bits bit="21">
-					<BitsShortName>TRACK_ANGLE_RATE_SIGN</BitsShortName>
-					<BitsName>Track Angle Rate Sign</BitsName>
-                    <BitsValue val="0">Plus</BitsValue>
-                    <BitsValue val="1">Minus</BitsValue>
-				</Bits>
-				<Bits from="20" to="12" encode="signed">
+				<Bits from="21" to="12" encode="signed">
 					<BitsShortName>TRACK_ANGLE_RATE</BitsShortName>
-					<BitsName>Track angle rate</BitsName>
+					<BitsName>Track Angle Rate</BitsName>
                     <BitsUnit scale="0.03125">deg/sec</BitsUnit>
 				</Bits>
 				<Bits bit="11">

--- a/install/config/asterix_bds.xml
+++ b/install/config/asterix_bds.xml
@@ -174,13 +174,7 @@
 					<BitsShortName>HDG_STAT</BitsShortName>
 					<BitsName>Heading Status</BitsName>
 				</Bits>
-				<Bits bit="55">
-					<BitsShortName>HDG_DIR</BitsShortName>
-					<BitsName>Head Direction</BitsName>
-                    <BitsValue val="0">East</BitsValue>
-                    <BitsValue val="1">West</BitsValue>
-				</Bits>
-				<Bits from="54" to="45" encode="unsigned">
+				<Bits from="55" to="45" encode="signed">
 					<BitsShortName>HDG</BitsShortName>
 					<BitsName>Magnetic Heading</BitsName>
                     <BitsUnit scale="0.17578125">deg</BitsUnit>
@@ -207,13 +201,7 @@
 					<BitsShortName>BAR_STAT</BitsShortName>
 					<BitsName>Barometric Altitude Rate Status</BitsName>
 				</Bits>
-				<Bits bit="21">
-					<BitsShortName>BAR_DIR</BitsShortName>
-					<BitsName>Barometric Altitude Rate Direction</BitsName>
-                    <BitsValue val="0">Above</BitsValue>
-                    <BitsValue val="1">Below</BitsValue>
-				</Bits>
-				<Bits from="20" to="12" encode="unsigned">
+				<Bits from="21" to="12" encode="signed">
 					<BitsShortName>BAR</BitsShortName>
 					<BitsName>Barometric Altitude Rate</BitsName>
                     <BitsUnit scale="32">ft/min</BitsUnit>
@@ -222,9 +210,9 @@
 					<BitsShortName>IVV_STAT</BitsShortName>
 					<BitsName>Inertial Vertical Velocity Status</BitsName>
 				</Bits>
-				<Bits from="10" to="1" encode="unsigned">
+				<Bits from="10" to="1" encode="signed">
 					<BitsShortName>IVV</BitsShortName>
-					<BitsName>Inertial Vertical Velocity </BitsName>
+					<BitsName>Inertial Vertical Velocity</BitsName>
                     <BitsUnit scale="32">ft/min</BitsUnit>
 				</Bits>
 			</Fixed>

--- a/install/config/asterix_bds.xml
+++ b/install/config/asterix_bds.xml
@@ -60,13 +60,13 @@
                     <BitsValue val="1">Active</BitsValue>
                 </Bits>
                 <Bits bit="7">
-                    <BitsShortName>ALTHOLD</BitsShortName>
+                    <BitsShortName>ALT_HOLD</BitsShortName>
 					<BitsName>ALT HOLD Mode</BitsName>
                     <BitsValue val="0">Not active</BitsValue>
                     <BitsValue val="1">Active</BitsValue>
                 </Bits>
                 <Bits bit="6">
-                    <BitsShortName>APPMODE</BitsShortName>
+                    <BitsShortName>APP</BitsShortName>
 					<BitsName>APPROACH Mode</BitsName>
                     <BitsValue val="0">Not active</BitsValue>
                     <BitsValue val="1">Active</BitsValue>
@@ -76,13 +76,13 @@
 					<BitsName>Reserved</BitsName>
 				</Bits>
                 <Bits bit="3">
-                    <BitsShortName>TARGETALTSTAT</BitsShortName>
+                    <BitsShortName>TARGET_ALT_STATUS</BitsShortName>
 					<BitsName>Status of Target ALT source bits</BitsName>
                     <BitsValue val="0">No source information provided</BitsValue>
                     <BitsValue val="1">Source information deliberately provided</BitsValue>
                 </Bits>
                 <Bits from="2" to="1">
-                    <BitsShortName>TARGETALTSRC</BitsShortName>
+                    <BitsShortName>TARGET_ALT_SOURCE</BitsShortName>
 					<BitsName>Target ALT source</BitsName>
                     <BitsValue val="0">Unknown</BitsValue>
                     <BitsValue val="1">Aircraft Altitude</BitsValue>
@@ -99,20 +99,20 @@
 		<DataItemFormat desc="Seven-octets fixed length data item.">
 			<Fixed length="7">
 				<Bits bit="56">
-					<BitsShortName>ROLL_STATUS</BitsShortName>
+					<BitsShortName>RA_STATUS</BitsShortName>
 					<BitsName>Roll Angle Status</BitsName>
 				</Bits>
 				<Bits from="55" to="46" encode="signed">
-					<BitsShortName>ROLL_ANGLE</BitsShortName>
+					<BitsShortName>RA</BitsShortName>
 					<BitsName>Roll Angle</BitsName>
                     <BitsUnit scale="0.17578125">deg</BitsUnit>
 				</Bits>
 				<Bits bit="45">
-					<BitsShortName>TRUE_TRACK_STATUS</BitsShortName>
+					<BitsShortName>TTA_STATUS</BitsShortName>
 					<BitsName>True Track Angle Status</BitsName>
 				</Bits>
 				<Bits from="44" to="34" encode="signed">
-					<BitsShortName>TRU_TRACK_ANGLE</BitsShortName>
+					<BitsShortName>TTA</BitsShortName>
 					<BitsName>True Track Angle</BitsName>
                     <BitsUnit scale="0.17578125">deg</BitsUnit>
 				</Bits>
@@ -126,11 +126,11 @@
                     <BitsUnit scale="2">kt</BitsUnit>
 				</Bits>
 				<Bits bit="22">
-					<BitsShortName>TRACK_ANGLE_RATE_STATUS</BitsShortName>
+					<BitsShortName>TAR_STATUS</BitsShortName>
 					<BitsName>Track Angle Rate Status</BitsName>
 				</Bits>
 				<Bits from="21" to="12" encode="signed">
-					<BitsShortName>TRACK_ANGLE_RATE</BitsShortName>
+					<BitsShortName>TAR</BitsShortName>
 					<BitsName>Track Angle Rate</BitsName>
                     <BitsUnit scale="0.03125">deg/sec</BitsUnit>
 				</Bits>
@@ -153,7 +153,7 @@
 		<DataItemFormat desc="Seven-octets fixed length data item.">
 			<Fixed length="7">
 				<Bits bit="56">
-					<BitsShortName>HDG_STAT</BitsShortName>
+					<BitsShortName>HDG_STATUS</BitsShortName>
 					<BitsName>Heading Status</BitsName>
 				</Bits>
 				<Bits from="55" to="45" encode="signed">
@@ -171,7 +171,7 @@
                     <BitsUnit scale="1">kt</BitsUnit>
 				</Bits>
 				<Bits bit="33">
-					<BitsShortName>MACH_STAT</BitsShortName>
+					<BitsShortName>MACH_STATUS</BitsShortName>
 					<BitsName>Mach Speed Status</BitsName>
 				</Bits>
 				<Bits from="32" to="23">
@@ -180,7 +180,7 @@
                     <BitsUnit scale=".004">MACH</BitsUnit>
 				</Bits>
 				<Bits bit="22">
-					<BitsShortName>BAR_STAT</BitsShortName>
+					<BitsShortName>BAR_STATUS</BitsShortName>
 					<BitsName>Barometric Altitude Rate Status</BitsName>
 				</Bits>
 				<Bits from="21" to="12" encode="signed">
@@ -189,7 +189,7 @@
                     <BitsUnit scale="32">ft/min</BitsUnit>
 				</Bits>
 				<Bits bit="11">
-					<BitsShortName>IVV_STAT</BitsShortName>
+					<BitsShortName>IVV_STATUS</BitsShortName>
 					<BitsName>Inertial Vertical Velocity Status</BitsName>
 				</Bits>
 				<Bits from="10" to="1" encode="signed">

--- a/install/config/asterix_cat048_1_14.xml
+++ b/install/config/asterix_cat048_1_14.xml
@@ -843,7 +843,7 @@
                 <Fixed length="1">
                     <Bits bit="8">
                         <BitsShortName>CNF</BitsShortName>
-                        <BitsName>CBF</BitsName>
+                        <BitsName>CNF</BitsName>
                         <BitsValue val="0">Confirmed Track</BitsValue>
                         <BitsValue val="1">Tentative Track</BitsValue>
                     </Bits>

--- a/install/config/asterix_cat048_1_21.xml
+++ b/install/config/asterix_cat048_1_21.xml
@@ -851,7 +851,7 @@
                 <Fixed length="1">
                     <Bits bit="8">
                         <BitsShortName>CNF</BitsShortName>
-                        <BitsName>CBF</BitsName>
+                        <BitsName>CNF</BitsName>
                         <BitsValue val="0">Confirmed Track</BitsValue>
                         <BitsValue val="1">Tentative Track</BitsValue>
                     </Bits>


### PR DESCRIPTION
Per ICAO9871 (Technical provision for Mode S Services) , two’s complement coding is used for all signed fields as specified in §A.2.2.2. So I think it is better to let asterix decode the fields as signed, like it is done with all the categories. 

Also, I have unificate the BitsShortName, so STATUS is always written the same (and not STAT or STATS). Also I have make the BitsShortName shorter, instead of TRUE_TRACK_ANGLE. TTA, which is commonly used.

Hope you find this useful.