### PR TITLE
add parsing with offset

### DIFF
--- a/asterix/__init__.py
+++ b/asterix/__init__.py
@@ -96,6 +96,7 @@ def describe(category, item=None, field=None, value=None):
         return _asterix.describe(category, item)
     return _asterix.describe(category)
 
+
 def parse(data):
     """ Parse raw asterix data
     Args:
@@ -106,6 +107,23 @@ def parse(data):
     if sys.version_info <= (2, 7):
         return _asterix.parse(buffer(data))
     return _asterix.parse(bytes(data))
+
+
+def parse_with_offset(data, offset=0, blocks_count=1000):
+    """ Parse raw asterix data with bytes offset with returning number of blocks of data 
+    passed with arguments
+    Args:
+        data: Bytes to be parsed
+        offset: bytes offset
+        blocks_count: number of blocks data to be returned
+    Returns:
+        tuple of two elements:
+            list of asterix records
+            bytes offset at ending of computation
+    """
+    if sys.version_info <= (2, 7):
+        return _asterix.parse_with_offset(buffer(data), offset, blocks_count)
+    return _asterix.parse_with_offset(bytes(data), offset, blocks_count)
 
 
 def describe(parsed):

--- a/src/asterix/InputParser.h
+++ b/src/asterix/InputParser.h
@@ -25,6 +25,7 @@
 #define INPUTPARSER_H_
 #include "AsterixDefinition.h"
 #include "AsterixData.h"
+#include "DataBlock.h"
 #include <ios>
 #include <iostream>
 #include <iomanip>
@@ -36,7 +37,9 @@ public:
   InputParser(AsterixDefinition* pDefinition);
   ~InputParser() { if (m_pDefinition) delete m_pDefinition; }
   AsterixData* parsePacket(const unsigned char* m_pBuffer, unsigned int m_nBufferSize, unsigned long nTimestamp = 0);
-
+  DataBlock* parse_next_data_block(const unsigned char* m_pData, unsigned int &m_nPos, unsigned int m_nBufferSize,
+    unsigned long nTimestamp, unsigned int &m_nDataLength);
+  
   std::string printDefinition();
   bool filterOutItem(int cat, std::string item, const char* name);
   bool isFiltered(int cat, std::string item, const char* name);

--- a/src/python/asterix.c
+++ b/src/python/asterix.c
@@ -40,6 +40,7 @@
 PyObject* say_hello(PyObject* self, PyObject *args, PyObject *kwargs);
 PyObject* init(PyObject* self, PyObject *args, PyObject *kwargs);
 PyObject* parse(PyObject* self, PyObject *args, PyObject *kwargs);
+PyObject* parse_with_offset(PyObject* self, PyObject *args, PyObject *kwargs);
 PyObject* describe(PyObject* self, PyObject *args, PyObject *kwargs);
 PyObject* set_callback(PyObject* self, PyObject *args);
 
@@ -50,6 +51,7 @@ static PyMethodDef asterixMethods[] = {
   {"init", (PyCFunction) init, METH_VARARGS | METH_KEYWORDS, "Initializes asterix converter" ENCODER_HELP_TEXT},
   {"describe", (PyCFunction) describe, METH_VARARGS, "Describe ASTERIX item" ENCODER_HELP_TEXT},
   {"parse", (PyCFunction) parse, METH_VARARGS | METH_KEYWORDS, "Parse ASTERIX data" ENCODER_HELP_TEXT},
+  {"parse_with_offset", (PyCFunction) parse_with_offset, METH_VARARGS | METH_KEYWORDS, "Parse ASTERIX data with bytes offset" ENCODER_HELP_TEXT},
   {"set_callback", (PyCFunction) set_callback, METH_VARARGS, "Set callback function" ENCODER_HELP_TEXT},
   {NULL, NULL, 0, NULL}       /* Sentinel */
 };

--- a/src/python/python_parser.h
+++ b/src/python/python_parser.h
@@ -34,6 +34,7 @@ extern "C" {
   int python_init(const char* ini_file_path);
   PyObject* python_describe(int category, const char* item, const char* field, const char* value);
   PyObject* python_parse(const unsigned char* pBuf, unsigned int len);
+  PyObject* python_parse_with_offset(const unsigned char* pBuf, unsigned int len, unsigned int offset, unsigned int blocks_count);
   void asterix_start(const char* ini_filename, const char* filename);
 
 #ifdef __cplusplus

--- a/src/python/python_wrapper.c
+++ b/src/python/python_wrapper.c
@@ -137,6 +137,40 @@ parse(PyObject* self, PyObject* args, PyObject *kwargs)
     return lstBlocks;
 }
 
+PyObject*
+parse_with_offset(PyObject* self, PyObject* args, PyObject *kwargs)
+/* parsing arguments with bytes offset with returning number of blocks of data passed
+ * with arguments
+ * AUTHOR: Krzysztof Rutkowski, ICM UW, krutk@icm.edu.pl
+*/
+{
+    const char* data;
+    Py_ssize_t len;
+    unsigned int offset;
+    unsigned int blocks_count;
+    //int len;
+
+    if (!PyArg_ParseTuple(args, "s#II", &data, &len, &offset, &blocks_count))
+        return NULL;
+
+    if (!bInitialized)
+    {
+        printf("Not initialized!");
+        return NULL;
+    }
+
+    PyObject *py_output = python_parse_with_offset((const unsigned char*) data, len, offset, blocks_count);
+    if (PyErr_Occurred())
+        return NULL;
+    if (py_output == NULL) 
+    {
+		PyObject* empty_list = PyList_New(0);
+		PyObject* offset_value = Py_BuildValue("l", offset); 
+        return PyTuple_Pack(2, empty_list, offset_value);
+	}
+    return py_output;
+}
+
 
 PyObject *
 set_callback(PyObject* self, PyObject *args)


### PR DESCRIPTION
I was adding a function parse_with_offset, which takes a bytes stream and reads it from some offset and reads only some number of data blocks. It is useful for our approaches where we have a very large byte streams and it allows us to parse data partially to save RAM memory.