### PR TITLE
Open asterix files in binary mode on non-unix systems (for mingw cross-compilation)

### DIFF
--- a/src/asterix/DataItemBits.cpp
+++ b/src/asterix/DataItemBits.cpp
@@ -180,7 +180,7 @@ unsigned long DataItemBits::getUnsigned(unsigned char* pData, int bytes, int fro
 
 	if (numberOfBits<1 || numberOfBits>32)
 	{
-		Tracer::Error("DataItemBits::getUnsigned : Wrong parameter.m Number of bits = %d, and must be between 1 and 32.", numberOfBits);
+		Tracer::Error("DataItemBits::getUnsigned : Wrong parameter.m Number of bits = %d, and must be between 1 and 32. Currently is from %d to %d", numberOfBits, tobit, frombit);
 	}
 	else
 	{

--- a/src/asterix/asterixgpssubformat.cxx
+++ b/src/asterix/asterixgpssubformat.cxx
@@ -175,10 +175,10 @@ bool CAsterixGPSSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, C
 			float fTimeStamp = ((GPSPost[6]<<16) + (GPSPost[7]<<8) + (GPSPost[8])) / 128.0;
 			unsigned long nTimeStamp = ((long)fTimeStamp) * 1000 + (fTimeStamp - ((long)fTimeStamp)) * 1000;
 #ifdef _DEBUG
-			LOGERROR(1, "GPS Bytes [%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]\n", GPSPost[0], GPSPost[1],
+			LOGDEBUG(1, "GPS Bytes [%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]\n", GPSPost[0], GPSPost[1],
 			    GPSPost[2], GPSPost[3], GPSPost[4], GPSPost[5], GPSPost[6], GPSPost[7],
 			    GPSPost[8], GPSPost[9]);
-			LOGERROR(1, "GPS Timestamp [%3.4f]\n", fTimeStamp);
+			LOGDEBUG(1, "GPS Timestamp [%3.4f]\n", fTimeStamp);
 #endif
 			Descriptor.SetTimeStamp(nTimeStamp);
 

--- a/src/engine/diskdevice.cxx
+++ b/src/engine/diskdevice.cxx
@@ -305,7 +305,7 @@ bool CDiskDevice::Init(const char *path)
          ASSERT( !(_mode & DD_MODE_PACKETFILE) ); // not supported for input
 //         ASSERT( !(_mode & DD_MODE_TEMPNAME) ); // not supported for input
 
-        _fileStream = fopen(fname, "r");
+        _fileStream = fopen(fname, "rb");
         _onstart = true;
     }
     else


### PR DESCRIPTION
When compiling inside linux to make windows binaries using MinGW, binary files (like asterix) shall be opened with "rb".