### PR TITLE
Extend XML output to match JSON output

### DIFF
--- a/src/asterix/DataItem.cpp
+++ b/src/asterix/DataItem.cpp
@@ -52,6 +52,9 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 	  case CAsterixFormat::EJSONH:
 		  strNewResult = format("\t\"I%s\":", m_pDescription->m_strID.c_str());
 		  break;
+	  case CAsterixFormat::EXML:
+		  strNewResult = format("\n<I%s>", m_pDescription->m_strID.c_str());
+		  break;
 	  case CAsterixFormat::ETxt:
 		  strNewResult = format("\n\nItem %s : %s", m_pDescription->m_strID.c_str(), m_pDescription->m_strName.c_str());
 		  strNewResult += format("\n[ ");
@@ -74,6 +77,9 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 
   switch(formatType)
 {
+	  case CAsterixFormat::EXML:
+		  strResult += format("\n</I%s>", m_pDescription->m_strID.c_str());
+		  break;
   	  case CAsterixFormat::EJSON:
   	  case CAsterixFormat::EJSONH:
 		  // replace last ',' with '}'

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -210,7 +210,7 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 		break;
 	case CAsterixFormat::EXML:
 		const int nXIDEFv = 1;
-		strNewResult = format("\n<ASTERIX ver=\"%d\" crc=\"%08X\" cat=\"%d\">", nXIDEFv, m_nCrc, m_pCategory->m_id);
+		strNewResult = format("\n<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pCategory->m_id);
 		break;
   }
 


### PR DESCRIPTION
By comparing the JSON and XML outputs for the same ASTERIX input file I noticed that the XML output lacks the _length_ and _timestamp_ attributes as well as the _Data Item descriptors_, which are all printed in the JSON output.

**XML:** `$ ./asterix --xml -f ../asterix/sample_data/cat034.raw`
```
<ASTERIXSTART>
<ASTERIX ver="1" crc="FAA2F997" cat="34">
<SAC>25</SAC>
<SIC>14</SIC>
<MsgTyp>2</MsgTyp>
<ToD>29906.3359375</ToD>
<Azi>90.0000000</Azi>
<NOGO>0</NOGO>
<RDPC>1</RDPC>
<RDPR>0</RDPR>
<OVLRDP>0</OVLRDP>
<OVLXMT>0</OVLXMT>
<MSC>0</MSC>
<TSV>0</TSV>
<spare>0</spare>
<SSRANT>0</SSRANT>
<SSRCHAB>2</SSRCHAB>
<SSROVL>0</SSROVL>
<SSRMSC>0</SSRMSC>
<spare>0</spare>
<spare>0</spare>
<REDRDP>0</REDRDP>
<REDXMT>0</REDXMT>
<spare>0</spare>
</ASTERIX>
```

**JSON:** `$ ./asterix --jsonh -f ../asterix/sample_data/cat034.raw`
```
{"id":1,
"length":13,
"crc":"FAA2F997",
"timestamp":85222575,
"CAT034":{
	"I010":{
		"SAC":25,
		"SIC":14},
	"I000":{
		"MsgTyp":2},
	"I030":{
		"ToD":29906.3359375},
	"I020":{
		"Azi":90.0000000},
	"I050":{
		"COM":{
		"NOGO":0,
		"RDPC":1,
		"RDPR":0,
		"OVLRDP":0,
		"OVLXMT":0,
		"MSC":0,
		"TSV":0,
		"spare":0},
		"SSR":{
		"SSRANT":0,
		"SSRCHAB":2,
		"SSROVL":0,
		"SSRMSC":0,
		"spare":0}},
	"I060":{
		"COM":{
		"spare":0,
		"REDRDP":0,
		"REDXMT":0,
		"spare":0}}}},
```

I don't know why such differences should exist between both formats.

For this reason, I have addressed the issue by adding the missing information to the XML output. With the changes in this PR, the XML output for the `cat034.raw` sample file now looks like this:

```
<ASTERIXSTART>
<ASTERIX ver="1" length="13" crc="FAA2F997" timestamp="85222575" cat="34">
<I010>
<SAC>25</SAC>
<SIC>14</SIC>
</I010>
<I000>
<MsgTyp>2</MsgTyp>
</I000>
<I030>
<ToD>29906.3359375</ToD>
</I030>
<I020>
<Azi>90.0000000</Azi>
</I020>
<I050>
<NOGO>0</NOGO>
<RDPC>1</RDPC>
<RDPR>0</RDPR>
<OVLRDP>0</OVLRDP>
<OVLXMT>0</OVLXMT>
<MSC>0</MSC>
<TSV>0</TSV>
<spare>0</spare>
<SSRANT>0</SSRANT>
<SSRCHAB>2</SSRCHAB>
<SSROVL>0</SSROVL>
<SSRMSC>0</SSRMSC>
<spare>0</spare>
</I050>
<I060>
<spare>0</spare>
<REDRDP>0</REDRDP>
<REDXMT>0</REDXMT>
<spare>0</spare>
</I060>
</ASTERIX>
```

Which provides more information to the user and better matches the JSON output.

Regardless of whether this PR is merged or not, I would be very grateful if I could get some feedback on my changes to take into consideration for future contributions.

Thank you.
Regards,

Álvaro