### PR TITLE
Export undecoded asterix data in output

### DIFF
--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -170,7 +170,7 @@ DataRecord::DataRecord(Category* cat, int nID, unsigned long len, const unsigned
     nCrc32 = crc32(&nSecondByteLength, 1, nCrc32);
     nCrc32 = crc32(data, len, nCrc32);
     m_nCrc = nCrc32;
-    m_pHexData = (char *) calloc( (len + 3 /*cat + len*/)*2 + 1 /* null */, sizeof(unsigned char) );
+    m_pHexData = (char *) calloc( (m_nLength + 3 /*cat + len*/)*2 + 1 /* null */, sizeof(unsigned char) );
     snprintf(m_pHexData,                  3, "%02X", (unsigned char) nCategory);
     snprintf(m_pHexData + sizeof(char)*2, 3, "%02X", (int) ((m_nLength + 3) >> 8 ) & 0xff);
     snprintf(m_pHexData + sizeof(char)*4, 3, "%02X", (int) (m_nLength + 3) & 0xff);

--- a/src/asterix/DataRecord.h
+++ b/src/asterix/DataRecord.h
@@ -40,7 +40,7 @@ public:
   unsigned char* m_pFSPECData;
   unsigned long m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
   uint32_t m_nCrc;
-
+  char* m_pHexData; // hexa conversion of data to display
   bool m_bFormatOK;
   std::list<DataItem*> m_lDataItems;
 


### PR DESCRIPTION
I usually need to filter Asterix packets based on some dataitems (for example, removing plots from cat 48 with ground bit set). Source and destination apps speak Asterix. So in order to do this, I need a program that sits in the middle, decoding and parsing Asterix and then letting pass only the approved datarecords. After checking the ground bit, with this PR I can generate the binary message instantly relaying in the hexdata field. Change field or variable names as better suits you, the key thing is  getting the binary datarecord.