### PR TITLE
use uniform spelling for twos and two's (in two's complement)

### DIFF
--- a/asterix/config/asterix_cat004_1_8.xml
+++ b/asterix/config/asterix_cat004_1_8.xml
@@ -764,12 +764,12 @@
                 <Fixed length="10">
                     <Bits from="80" to="49" encode="signed">
                         <BitsShortName>Latitude</BitsShortName>
-                        <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                        <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="48" to="17" encode="signed">
                         <BitsShortName>Longitude</BitsShortName>
-                        <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                        <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="16" to="1" encode="signed">
@@ -999,12 +999,12 @@
                 <Fixed length="10">
                     <Bits from="80" to="49" encode="signed">
                         <BitsShortName>Latitude</BitsShortName>
-                        <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                        <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="48" to="17" encode="signed">
                         <BitsShortName>Longitude</BitsShortName>
-                        <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                        <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="16" to="1" encode="signed">

--- a/asterix/config/asterix_cat010_1_1.xml
+++ b/asterix/config/asterix_cat010_1_1.xml
@@ -182,12 +182,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/config/asterix_cat011_1_2.xml
+++ b/asterix/config/asterix_cat011_1_2.xml
@@ -70,12 +70,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/config/asterix_cat019_1_2.xml
+++ b/asterix/config/asterix_cat019_1_2.xml
@@ -230,12 +230,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/config/asterix_cat020_1_7.xml
+++ b/asterix/config/asterix_cat020_1_7.xml
@@ -162,12 +162,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.000005364418029785156" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.000005364418029785156" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/config/asterix_cat021_2_4.xml
+++ b/asterix/config/asterix_cat021_2_4.xml
@@ -705,12 +705,12 @@
             <Fixed length="6">
                 <Bits from="25" to="48" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
                 <Bits from="1" to="24" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -725,7 +725,7 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude In WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude In WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">

--- a/asterix/config/asterix_cat025_1_2.xml
+++ b/asterix/config/asterix_cat025_1_2.xml
@@ -240,12 +240,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000004190951586">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000008381903172">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/config/asterix_cat062_1_17.xml
+++ b/asterix/config/asterix_cat062_1_17.xml
@@ -384,12 +384,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -562,7 +562,7 @@
                 <Fixed length="1">
                     <Bits from="1" to="8" encode="signed">
                         <BitsShortName>TOS</BitsShortName>
-                        <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                        <BitsName>Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
                         <BitsUnit scale="0.0078125">s</BitsUnit>                        
                     </Bits>
                 </Fixed>
@@ -1994,12 +1994,12 @@
                         </Bits>
                         <Bits from="96" to="73" encode="signed">
                             <BitsShortName>Lat</BitsShortName>
-                            <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
+                            <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="72" to="49" encode="signed">
                             <BitsShortName>Lon</BitsShortName>
-                            <BitsName>Longitude In WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                            <BitsName>Longitude In WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="48" to="45">

--- a/asterix/config/asterix_cat205_1_0.xml
+++ b/asterix/config/asterix_cat205_1_0.xml
@@ -97,12 +97,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -217,12 +217,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/asterix/test/test_parse.py
+++ b/asterix/test/test_parse.py
@@ -286,9 +286,9 @@ class AsterixParseTest(unittest.TestCase):
 
             self.assertEqual(packet[0]['I105'], {
                 'Lat': {'val': 44.73441302776337,
-                        'desc': 'Latitude in WGS.84 in twos complement. Range -90 < latitude < 90 deg.'},
+                        'desc': 'Latitude in WGS.84 in two's complement. Range -90 < latitude < 90 deg.'},
                 'Lon': {'val': 13.0415278673172,
-                        'desc': 'Longitude in WGS.84 in twos complement. Range -180 < longitude < 180 deg.'}})
+                        'desc': 'Longitude in WGS.84 in two's complement. Range -180 < longitude < 180 deg.'}})
             self.assertEqual(packet[0]['I040'], {'TrkN': {'val': 4980, 'desc': 'Track number'}})
             self.assertEqual(packet[0]['I210'], {'Ax': {'val': 0.0, 'desc': 'Ax'}, 'Ay': {'val': 0.0, 'desc': 'Ay'}})
             self.assertEqual(packet[1]['I220'], {'RoC': {'val': 0.0, 'desc': 'Rate of Climb/Descent'}})
@@ -425,9 +425,9 @@ class AsterixParseTest(unittest.TestCase):
             self.assertEqual(packet[1]['I380']['ID'], {'ACID': {'val': 'SXD4723 ', 'desc': 'Target Identification'}})
 
             self.assertEqual(packet[1]['I105'], {'Lat': {'val': 45.40080785751343,
-                                                         'desc': 'Latitude in WGS.84 in twos complement. Range -90 < latitude < 90 deg.'},
+                                                         'desc': 'Latitude in WGS.84 in two's complement. Range -90 < latitude < 90 deg.'},
                                                  'Lon': {'val': 15.13318419456482,
-                                                         'desc': 'Longitude in WGS.84 in twos complement. Range -180 < longitude < 180 deg.'}})
+                                                         'desc': 'Longitude in WGS.84 in two's complement. Range -180 < longitude < 180 deg.'}})
             self.assertEqual(packet[1]['I040'], {'TrkN': {'val': 7977, 'desc': 'Track number'}})
             self.assertEqual(packet[1]['I210'], {'Ax': {'val': 0.0, 'desc': 'Ax'}, 'Ay': {'val': 0.0, 'desc': 'Ay'}})
             self.assertEqual(packet[2]['I015'], {'SID': {'val': 4, 'desc': 'Service Identification'}})

--- a/install/config/asterix_cat004_1_8.xml
+++ b/install/config/asterix_cat004_1_8.xml
@@ -764,12 +764,12 @@
                 <Fixed length="10">
                     <Bits from="80" to="49" encode="signed">
                         <BitsShortName>Latitude</BitsShortName>
-                        <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                        <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="48" to="17" encode="signed">
                         <BitsShortName>Longitude</BitsShortName>
-                        <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                        <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="16" to="1" encode="signed">
@@ -999,12 +999,12 @@
                 <Fixed length="10">
                     <Bits from="80" to="49" encode="signed">
                         <BitsShortName>Latitude</BitsShortName>
-                        <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                        <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="48" to="17" encode="signed">
                         <BitsShortName>Longitude</BitsShortName>
-                        <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                        <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                         <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                     </Bits>
                     <Bits from="16" to="1" encode="signed">

--- a/install/config/asterix_cat010_1_1.xml
+++ b/install/config/asterix_cat010_1_1.xml
@@ -182,12 +182,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat011_1_2.xml
+++ b/install/config/asterix_cat011_1_2.xml
@@ -70,12 +70,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000008381903171539306640625" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat019_1_2.xml
+++ b/install/config/asterix_cat019_1_2.xml
@@ -230,12 +230,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat020_1_7.xml
+++ b/install/config/asterix_cat020_1_7.xml
@@ -162,12 +162,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.000005364418029785156" min="-90" max="90">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement.</BitsName>
                     <BitsUnit scale="0.000005364418029785156" min="-180" max="180">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat021_0_23.xml
+++ b/install/config/asterix_cat021_0_23.xml
@@ -426,12 +426,12 @@
             <Fixed length="6">
                 <Bits from="48" to="25" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= latitude &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= latitude &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00002145767212">deg</BitsUnit>
                 </Bits>
                 <Bits from="24" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00002145767212">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat021_0_26.xml
+++ b/install/config/asterix_cat021_0_26.xml
@@ -426,12 +426,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= latitude &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= latitude &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat021_1_8.xml
+++ b/install/config/asterix_cat021_1_8.xml
@@ -634,12 +634,12 @@
             <Fixed length="6">
                 <Bits from="25" to="48" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
                 <Bits from="1" to="24" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -653,7 +653,7 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude In WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude In WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">

--- a/install/config/asterix_cat021_2_1_RE_1_1.xml
+++ b/install/config/asterix_cat021_2_1_RE_1_1.xml
@@ -680,12 +680,12 @@
             <Fixed length="6">
                 <Bits from="48" to="25" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
                 <Bits from="24" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -699,7 +699,7 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude In WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude In WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">

--- a/install/config/asterix_cat021_2_4.xml
+++ b/install/config/asterix_cat021_2_4.xml
@@ -705,12 +705,12 @@
             <Fixed length="6">
                 <Bits from="25" to="48" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
                 <Bits from="1" to="24" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -725,7 +725,7 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude In WGS.84 in twos complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsName>Latitude In WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
                     <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">

--- a/install/config/asterix_cat025_1_2.xml
+++ b/install/config/asterix_cat025_1_2.xml
@@ -240,12 +240,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000004190951586">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000008381903172">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/config/asterix_cat062_1_16.xml
+++ b/install/config/asterix_cat062_1_16.xml
@@ -375,12 +375,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -553,7 +553,7 @@
                 <Fixed length="1">
                     <Bits from="1" to="8" encode="signed">
                         <BitsShortName>TOS</BitsShortName>
-                        <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                        <BitsName>Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
                         <BitsUnit scale="0.0078125">s</BitsUnit>                        
                     </Bits>
                 </Fixed>
@@ -1985,12 +1985,12 @@
                         </Bits>
                         <Bits from="96" to="73" encode="signed">
                             <BitsShortName>Lat</BitsShortName>
-                            <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
+                            <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="72" to="49" encode="signed">
                             <BitsShortName>Lon</BitsShortName>
-                            <BitsName>Longitude In WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                            <BitsName>Longitude In WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="48" to="45">

--- a/install/config/asterix_cat062_1_17.xml
+++ b/install/config/asterix_cat062_1_17.xml
@@ -384,12 +384,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -562,7 +562,7 @@
                 <Fixed length="1">
                     <Bits from="1" to="8" encode="signed">
                         <BitsShortName>TOS</BitsShortName>
-                        <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                        <BitsName>Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
                         <BitsUnit scale="0.0078125">s</BitsUnit>                        
                     </Bits>
                 </Fixed>
@@ -1994,12 +1994,12 @@
                         </Bits>
                         <Bits from="96" to="73" encode="signed">
                             <BitsShortName>Lat</BitsShortName>
-                            <BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
+                            <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="72" to="49" encode="signed">
                             <BitsShortName>Lon</BitsShortName>
-                            <BitsName>Longitude In WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                            <BitsName>Longitude In WGS.84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
                         </Bits>
                         <Bits from="48" to="45">

--- a/install/config/asterix_cat062_1_7.xml
+++ b/install/config/asterix_cat062_1_7.xml
@@ -476,7 +476,7 @@
                     <Fixed length="1">
                         <Bits from="1" to="8" encode="signed">
                             <BitsShortName>TOS</BitsShortName>
-                            <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                            <BitsName>Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
                             <BitsUnit scale="0.0078125">s</BitsUnit>						
                         </Bits>
                     </Fixed>

--- a/install/config/asterix_cat062_1_9.xml
+++ b/install/config/asterix_cat062_1_9.xml
@@ -290,12 +290,12 @@
 			<Fixed length="8">
 				<Bits from="33" to="64">
 					<BitsShortName>Lat</BitsShortName>
-					<BitsName>Latitude in WGS.84 in twos complement. Range -90 ≤ Latitude ≤ 90 deg.</BitsName>
+					<BitsName>Latitude in WGS.84 in two's complement. Range -90 ≤ Latitude ≤ 90 deg.</BitsName>
 					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
 				</Bits>
 				<Bits from="1" to="32">
 					<BitsShortName>Lon</BitsShortName>
-					<BitsName>Longitude in WGS.84 in twos complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
+					<BitsName>Longitude in WGS.84 in two's complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
 					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
 				</Bits>
 			</Fixed>
@@ -425,12 +425,12 @@
                     <Fixed length="6">
                         <Bits from="25" to="48">
 							<BitsShortName>Lat</BitsShortName>
-							<BitsName>Latitude in WGS.84 in twos complement. Range -90 ≤ Lat ≤ 90 deg.</BitsName>
+							<BitsName>Latitude in WGS.84 in two's complement. Range -90 ≤ Lat ≤ 90 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                         </Bits>
                         <Bits from="1" to="24">
 							<BitsShortName>Lon</BitsShortName>
-							<BitsName>Longitude in WGS.84 in twos complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
+							<BitsName>Longitude in WGS.84 in two's complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
                             <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
                         </Bits>
                     </Fixed>
@@ -465,7 +465,7 @@
                     <Fixed length="1">
                         <Bits from="1" to="8">
                             <BitsShortName>TOS</BitsShortName>
-                            <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                            <BitsName>Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
                             <BitsUnit scale="0.0078125">s</BitsUnit>						
                         </Bits>
                     </Fixed>

--- a/install/config/asterix_cat205_1_0.xml
+++ b/install/config/asterix_cat205_1_0.xml
@@ -97,12 +97,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>
@@ -217,12 +217,12 @@
             <Fixed length="8">
                 <Bits from="64" to="33" encode="signed">
                     <BitsShortName>Lat</BitsShortName>
-                    <BitsName>Latitude in WGS-84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+                    <BitsName>Latitude in WGS-84 in two's complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
                 <Bits from="32" to="1" encode="signed">
                     <BitsShortName>Lon</BitsShortName>
-                    <BitsName>Longitude in WGS-84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+                    <BitsName>Longitude in WGS-84 in two's complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
                     <BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
                 </Bits>
             </Fixed>

--- a/install/sample_output/filter.txt
+++ b/install/sample_output/filter.txt
@@ -191,8 +191,8 @@ CAT004:I120:CD                                               Conflict duration
 CAT004:I170:AI1                                              Aircraft Identifier 1
 CAT004:I170:spare                                            Spare bits set to 0
 CAT004:I170:M31                                              Mode 3/A Code Aircraft 1
-CAT004:I170:Latitude                                         Latitude in WGS.84 in twos complement. Range -90 < latitude < 90 deg.
-CAT004:I170:Longitude                                        Longitude in WGS.84 in twos complement. Range -180 < longitude < 180 deg.
+CAT004:I170:Latitude                                         Latitude in WGS.84 in two's complement. Range -90 < latitude < 90 deg.
+CAT004:I170:Longitude                                        Longitude in WGS.84 in two's complement. Range -180 < longitude < 180 deg.
 CAT004:I170:Altitude                                         Altitude of predicted conflict
 CAT004:I170:X                                                Starting X-position of the conflict
 CAT004:I170:Y                                                Starting Y-position of the conflict
@@ -216,8 +216,8 @@ CAT004:I170:CFL                                              Cleared Flight Leve
 CAT004:I171:AI2                                              Aircraft Identifier 2
 CAT004:I171:spare                                            Spare bits set to 0
 CAT004:I171:M32                                              Mode 3/A Code Aircraft 2
-CAT004:I171:Latitude                                         Latitude in WGS.84 in twos complement. Range -90 < latitude < 90 deg.
-CAT004:I171:Longitude                                        Longitude in WGS.84 in twos complement. Range -180 < longitude < 180 deg.
+CAT004:I171:Latitude                                         Latitude in WGS.84 in two's complement. Range -90 < latitude < 90 deg.
+CAT004:I171:Longitude                                        Longitude in WGS.84 in two's complement. Range -180 < longitude < 180 deg.
 CAT004:I171:Altitude                                         Altitude of predicted conflict
 CAT004:I171:X                                                Starting X-position of the conflict
 CAT004:I171:Y                                                Starting Y-position of the conflict
@@ -313,8 +313,8 @@ CAT010:I020:spare                                            Spare bit set to 0
 CAT010:I020:FX                                               
 CAT010:I040:RHO                                              RHO
 CAT010:I040:Theta                                            Theta
-CAT010:I041:Lat                                              Latitude in WGS-84 in twos complement.
-CAT010:I041:Lon                                              Longitude in WGS-84 in twos complement.
+CAT010:I041:Lat                                              Latitude in WGS-84 in two's complement.
+CAT010:I041:Lon                                              Longitude in WGS-84 in two's complement.
 CAT010:I042:X                                                X
 CAT010:I042:Y                                                Y
 CAT010:I060:V                                                V
@@ -449,8 +449,8 @@ CAT011:I000:MsgTyp                                           Type of msg.
 CAT011:I010:SAC                                              System Area Code fixed to zero
 CAT011:I010:SIC                                              System Identification Code
 CAT011:I015:SI                                               the service identification is allocated by the A-SMGCS
-CAT011:I041:Lat                                              Latitude in WGS-84 in twos complement.
-CAT011:I041:Lon                                              Longitude in WGS-84 in twos complement.
+CAT011:I041:Lat                                              Latitude in WGS-84 in two's complement.
+CAT011:I041:Lon                                              Longitude in WGS-84 in two's complement.
 CAT011:I042:X                                                X
 CAT011:I042:Y                                                Y
 CAT011:I060:spare                                            Spare bit set to 0
@@ -650,8 +650,8 @@ CAT019:I553:spare                                            Spare bit set to ze
 CAT019:I553:ref_trans_2                                      Ref Trans 2 Status
 CAT019:I553:spare                                            Spare bit set to zero
 CAT019:I553:FX                                               
-CAT019:I600:Lat                                              Latitude in WGS-84 in twos complement.
-CAT019:I600:Lon                                              Longitude in WGS-84 in twos complement.
+CAT019:I600:Lat                                              Latitude in WGS-84 in two's complement.
+CAT019:I600:Lon                                              Longitude in WGS-84 in two's complement.
 CAT019:I610:height                                           Height (WGS-84) above MSL
 CAT019:I620:undulation                                       WGS-84 Undulation value (MSL)
 CAT020:I010:SAC                                              System Area Code
@@ -674,8 +674,8 @@ CAT020:I020:TST
 CAT020:I020:FX                                               
 CAT020:I030:W_E                                              (W/E Value) Warning/error condition value
 CAT020:I030:FX                                               
-CAT020:I041:Lat                                              Latitude in WGS-84 in twos complement.
-CAT020:I041:Lon                                              Longitude in WGS-84 in twos complement.
+CAT020:I041:Lat                                              Latitude in WGS-84 in two's complement.
+CAT020:I041:Lon                                              Longitude in WGS-84 in two's complement.
 CAT020:I042:X                                                X
 CAT020:I042:Y                                                Y
 CAT020:I050:V                                                V
@@ -925,9 +925,9 @@ CAT021:I110:TRA                                              Turn Radius Availab
 CAT021:I110:TOA                                              
 CAT021:I110:TOV                                              Time Over Point
 CAT021:I110:TTR                                              TCP Turn radius
-CAT021:I130:Lat                                              Latitude in WGS.84 in twos complement. Range -90 <= Lat <= 90 deg.
-CAT021:I130:Lon                                              Longitude in WGS.84 in twos complement. Range -180 <= longitude < 180 deg.
-CAT021:I131:Lat                                              Latitude In WGS.84 in twos complement. Range -90 <= Lat <= 90 deg.
+CAT021:I130:Lat                                              Latitude in WGS.84 in two's complement. Range -90 <= Lat <= 90 deg.
+CAT021:I130:Lon                                              Longitude in WGS.84 in two's complement. Range -180 <= longitude < 180 deg.
+CAT021:I131:Lat                                              Latitude In WGS.84 in two's complement. Range -90 <= Lat <= 90 deg.
 CAT021:I131:Lon                                              Longitude In WGS.84 in two's complement. Range -180 <= longitude < 180 deg.
 CAT021:I132:MAM                                              Message Amplitude
 CAT021:I140:geometric_height                                 Geometric Height
@@ -1701,8 +1701,8 @@ CAT062:I080:spare                                            Spare bits set to 0
 CAT062:I080:FX                                               
 CAT062:I100:X                                                X
 CAT062:I100:Y                                                Y
-CAT062:I105:Lat                                              Latitude in WGS.84 in twos complement. Range -90 < latitude < 90 deg.
-CAT062:I105:Lon                                              Longitude in WGS.84 in twos complement. Range -180 < longitude < 180 deg.
+CAT062:I105:Lat                                              Latitude in WGS.84 in two's complement. Range -90 < latitude < 90 deg.
+CAT062:I105:Lon                                              Longitude in WGS.84 in two's complement. Range -180 < longitude < 180 deg.
 CAT062:I110:M5                                               
 CAT062:I110:ID                                               
 CAT062:I110:DA                                               
@@ -1724,7 +1724,7 @@ CAT062:I110:RES                                              Resolution with whi
 CAT062:I110:GA                                               GNSS-derived Altitude of target, expressed as height above WGS 84 ellipsoid.
 CAT062:I110:spare                                            spare bits set to 0
 CAT062:I110:EM1                                              Extended Mode 1 Code in octal representation
-CAT062:I110:TOS                                              Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.
+CAT062:I110:TOS                                              Time Offset coded as a two's complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.
 CAT062:I110:spare                                            spare bits set to 0
 CAT062:I110:X5                                               X-pulse from Mode 5 Data reply or Report.
 CAT062:I110:XC                                               X-pulse from Mode C reply
@@ -1837,8 +1837,8 @@ CAT062:I380:TCA                                              TCP number availabi
 CAT062:I380:NC                                               TCP compliance
 CAT062:I380:TCPnum                                           Trajectory Change Point number
 CAT062:I380:Alt                                              Altitude
-CAT062:I380:Lat                                              Latitude in WGS.84 in twos complement. Range -90 < Lat < 90 deg.
-CAT062:I380:Lon                                              Longitude In WGS.84 in twos complement. Range -180 < longitude < 180 deg.
+CAT062:I380:Lat                                              Latitude in WGS.84 in two's complement. Range -90 < Lat < 90 deg.
+CAT062:I380:Lon                                              Longitude In WGS.84 in two's complement. Range -180 < longitude < 180 deg.
 CAT062:I380:PT                                               Point type
 CAT062:I380:TD                                               Turn Direction
 CAT062:I380:TRA                                              Turn Radius Availability


### PR DESCRIPTION
Some fields had different spellings, eg CAT021:I131:Lat and Lon, where one was spelled as twos and the other as two's.

Change them all to a common (the correct) spelling.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>