### PR TITLE
Add line-delimited XML output format and add indentation to standard XML output

### DIFF
--- a/src/asterix/DataItem.cpp
+++ b/src/asterix/DataItem.cpp
@@ -55,6 +55,9 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 	  case CAsterixFormat::EXML:
 		  strNewResult = format("\n<I%s>", m_pDescription->m_strID.c_str());
 		  break;
+	  case CAsterixFormat::EXMLLines:
+		  strNewResult = format("<I%s>", m_pDescription->m_strID.c_str());
+		  break;
 	  case CAsterixFormat::ETxt:
 		  strNewResult = format("\n\nItem %s : %s", m_pDescription->m_strID.c_str(), m_pDescription->m_strName.c_str());
 		  strNewResult += format("\n[ ");
@@ -79,6 +82,9 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 {
 	  case CAsterixFormat::EXML:
 		  strResult += format("\n</I%s>", m_pDescription->m_strID.c_str());
+		  break;
+	  case CAsterixFormat::EXMLLines:
+		  strResult += format("</I%s>", m_pDescription->m_strID.c_str());
 		  break;
   	  case CAsterixFormat::EJSON:
   	  case CAsterixFormat::EJSONH:

--- a/src/asterix/DataItem.cpp
+++ b/src/asterix/DataItem.cpp
@@ -43,6 +43,7 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 {
   std::string newHeader;
   std::string strNewResult;
+  std::string indent("  "); // Two spaces make an indent.
 
   switch(formatType)
   {
@@ -53,7 +54,8 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 		  strNewResult = format("\t\"I%s\":", m_pDescription->m_strID.c_str());
 		  break;
 	  case CAsterixFormat::EXML:
-		  strNewResult = format("\n<I%s>", m_pDescription->m_strID.c_str());
+		  strNewResult += format("\n%s%s", indent.c_str(), indent.c_str()); // New line and indent 2 levels (4 spaces).
+		  strNewResult += format("<I%s>", m_pDescription->m_strID.c_str());
 		  break;
 	  case CAsterixFormat::EXMLLines:
 		  strNewResult = format("<I%s>", m_pDescription->m_strID.c_str());
@@ -81,7 +83,8 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
   switch(formatType)
 {
 	  case CAsterixFormat::EXML:
-		  strResult += format("\n</I%s>", m_pDescription->m_strID.c_str());
+		  strResult += format("\n%s%s", indent.c_str(), indent.c_str()); // New line and indent 2 levels (4 spaces).
+		  strResult += format("</I%s>", m_pDescription->m_strID.c_str());
 		  break;
 	  case CAsterixFormat::EXMLLines:
 		  strResult += format("</I%s>", m_pDescription->m_strID.c_str());

--- a/src/asterix/DataItem.cpp
+++ b/src/asterix/DataItem.cpp
@@ -43,7 +43,7 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 {
   std::string newHeader;
   std::string strNewResult;
-  std::string indent("  "); // Two spaces make an indent.
+  std::string indent("    ");  // 4 spaces make an indent.
 
   switch(formatType)
   {
@@ -54,11 +54,11 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
 		  strNewResult = format("\t\"I%s\":", m_pDescription->m_strID.c_str());
 		  break;
 	  case CAsterixFormat::EXML:
-		  strNewResult += format("\n%s%s", indent.c_str(), indent.c_str()); // New line and indent 2 levels (4 spaces).
-		  strNewResult += format("<I%s>", m_pDescription->m_strID.c_str());
-		  break;
-	  case CAsterixFormat::EXMLLines:
 		  strNewResult = format("<I%s>", m_pDescription->m_strID.c_str());
+		  break;
+	  case CAsterixFormat::EXMLH:
+		  strNewResult = format("\n%s", indent.c_str());  // New line and indent 1 level (4 spaces).
+		  strNewResult += format("<I%s>", m_pDescription->m_strID.c_str());
 		  break;
 	  case CAsterixFormat::ETxt:
 		  strNewResult = format("\n\nItem %s : %s", m_pDescription->m_strID.c_str(), m_pDescription->m_strName.c_str());
@@ -83,10 +83,10 @@ bool DataItem::getText(std::string& strResult, std::string& strHeader, const uns
   switch(formatType)
 {
 	  case CAsterixFormat::EXML:
-		  strResult += format("\n%s%s", indent.c_str(), indent.c_str()); // New line and indent 2 levels (4 spaces).
 		  strResult += format("</I%s>", m_pDescription->m_strID.c_str());
 		  break;
-	  case CAsterixFormat::EXMLLines:
+	  case CAsterixFormat::EXMLH:
+		  strResult += format("\n%s", indent.c_str());  // New line and indent 1 levels (4 spaces).
 		  strResult += format("</I%s>", m_pDescription->m_strID.c_str());
 		  break;
   	  case CAsterixFormat::EJSON:

--- a/src/asterix/DataItemBits.cpp
+++ b/src/asterix/DataItemBits.cpp
@@ -441,6 +441,9 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 	case CAsterixFormat::EXML:
 		strResult += format("\n<%s>", m_strShortName.c_str());
 		break;
+	case CAsterixFormat::EXMLLines:
+		strResult += format("<%s>", m_strShortName.c_str());
+		break;
 	}
 
 	switch(m_eEncoding)
@@ -720,6 +723,7 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 		strResult += format(",");
 		break;
 	case CAsterixFormat::EXML:
+	case CAsterixFormat::EXMLLines:
 		strResult += format("</%s>", m_strShortName.c_str());
 		break;
 	}

--- a/src/asterix/DataItemBits.cpp
+++ b/src/asterix/DataItemBits.cpp
@@ -430,7 +430,7 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 	else if (m_strShortName.empty())
 		m_strShortName = m_strName;
 
-	std::string indent("  "); // Two spaces make an indent.
+	std::string indent("    ");  // 4 spaces make an indent.
 
 	switch(formatType)
 	{
@@ -441,10 +441,10 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 		strResult += format("\n\t\t\"%s\":", m_strShortName.c_str());
 		break;
 	case CAsterixFormat::EXML:
-		strResult += format("\n%s%s%s", indent.c_str(), indent.c_str(), indent.c_str()); // New line and indent 3 levels (6 spaces).
 		strResult += format("<%s>", m_strShortName.c_str());
 		break;
-	case CAsterixFormat::EXMLLines:
+	case CAsterixFormat::EXMLH:
+		strResult += format("\n%s%s", indent.c_str(), indent.c_str());  // New line and indent 2 levels (8 spaces).
 		strResult += format("<%s>", m_strShortName.c_str());
 		break;
 	}
@@ -726,7 +726,7 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 		strResult += format(",");
 		break;
 	case CAsterixFormat::EXML:
-	case CAsterixFormat::EXMLLines:
+	case CAsterixFormat::EXMLH:
 		strResult += format("</%s>", m_strShortName.c_str());
 		break;
 	}

--- a/src/asterix/DataItemBits.cpp
+++ b/src/asterix/DataItemBits.cpp
@@ -430,6 +430,8 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 	else if (m_strShortName.empty())
 		m_strShortName = m_strName;
 
+	std::string indent("  "); // Two spaces make an indent.
+
 	switch(formatType)
 	{
 	case CAsterixFormat::EJSON:
@@ -439,7 +441,8 @@ bool DataItemBits::getText(std::string& strResult, std::string& strHeader, const
 		strResult += format("\n\t\t\"%s\":", m_strShortName.c_str());
 		break;
 	case CAsterixFormat::EXML:
-		strResult += format("\n<%s>", m_strShortName.c_str());
+		strResult += format("\n%s%s%s", indent.c_str(), indent.c_str(), indent.c_str()); // New line and indent 3 levels (6 spaces).
+		strResult += format("<%s>", m_strShortName.c_str());
 		break;
 	case CAsterixFormat::EXMLLines:
 		strResult += format("<%s>", m_strShortName.c_str());

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -225,9 +225,17 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 		strNewResult = format("{\"id\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%ld,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n", m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
 		break;
 	case CAsterixFormat::EXML:
+	{
 		const int nXIDEFv = 1;
 		strNewResult = format("\n<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
 		break;
+	}
+	case CAsterixFormat::EXMLLines:
+	{
+		const int nXLINESIDEFv = 1;
+		strNewResult = format("<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXLINESIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+		break;
+	}
   }
 
   // go through all present data items in this block
@@ -273,6 +281,9 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 			break;
 		case CAsterixFormat::EXML:
 			strResult += "\n</ASTERIX>";
+			break;
+		case CAsterixFormat::EXMLLines:
+			strResult += "</ASTERIX>\n";
 			break;
     }
   }

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -208,7 +208,6 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 	}
 
 	std::string strNewResult;
-	std::string indent("  "); // Two spaces make an indent.
 
 	switch(formatType)
 	{
@@ -226,16 +225,10 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 		strNewResult = format("{\"id\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%ld,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n", m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
 		break;
 	case CAsterixFormat::EXML:
+	case CAsterixFormat::EXMLH:
 	{
 		const int nXIDEFv = 1;
-		strNewResult += format("\n%s", indent.c_str()); // New line and indent 1 level (2 spaces).
-		strNewResult += format("<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
-		break;
-	}
-	case CAsterixFormat::EXMLLines:
-	{
-		const int nXLINESIDEFv = 1;
-		strNewResult = format("<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXLINESIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+		strNewResult = format("<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
 		break;
 	}
   }
@@ -278,15 +271,16 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 		switch(formatType)
     {
 		case CAsterixFormat::EJSON:
+			strResult += "}}\n";
+			break;
 		case CAsterixFormat::EJSONH:
 			strResult += "}},\n";
 			break;
 		case CAsterixFormat::EXML:
-			strResult += format("\n%s", indent.c_str()); // New line and indent 1 level (2 spaces).
-			strResult += "</ASTERIX>";
-			break;
-		case CAsterixFormat::EXMLLines:
 			strResult += "</ASTERIX>\n";
+			break;
+		case CAsterixFormat::EXMLH:
+			strResult += "\n</ASTERIX>\n";
 			break;
     }
   }

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -208,6 +208,7 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 	}
 
 	std::string strNewResult;
+	std::string indent("  "); // Two spaces make an indent.
 
 	switch(formatType)
 	{
@@ -227,7 +228,8 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 	case CAsterixFormat::EXML:
 	{
 		const int nXIDEFv = 1;
-		strNewResult = format("\n<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+		strNewResult += format("\n%s", indent.c_str()); // New line and indent 1 level (2 spaces).
+		strNewResult += format("<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">", nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
 		break;
 	}
 	case CAsterixFormat::EXMLLines:
@@ -280,7 +282,8 @@ bool DataRecord::getText(std::string& strResult, std::string& strHeader, const u
 			strResult += "}},\n";
 			break;
 		case CAsterixFormat::EXML:
-			strResult += "\n</ASTERIX>";
+			strResult += format("\n%s", indent.c_str()); // New line and indent 1 level (2 spaces).
+			strResult += "</ASTERIX>";
 			break;
 		case CAsterixFormat::EXMLLines:
 			strResult += "</ASTERIX>\n";

--- a/src/asterix/asterixformat.cxx
+++ b/src/asterix/asterixformat.cxx
@@ -46,7 +46,7 @@ const char* CAsterixFormat::_FormatName[CAsterixFormat::ETotalFormats] =
   "ASTERIX_TXT",
   "ASTERIX_FINAL",
   "ASTERIX_XML",
-  "ASTERIX_XML_LINES",
+  "ASTERIX_XMLH",
   "ASTERIX_JSON",
   "ASTERIX_JSONH",
   "ASTERIX_HDLC",
@@ -78,7 +78,7 @@ bool CAsterixFormat::ReadPacket(CBaseFormatDescriptor& formatDescriptor, CBaseDe
       case EGPS:
           return CAsterixGPSSubformat::ReadPacket(formatDescriptor, device, discard);
       case EXML:
-      case EXMLLines:
+      case EXMLH:
       case EJSON:
       case EJSONH:
           //todo not supported
@@ -111,17 +111,7 @@ bool CAsterixFormat::WritePacket(CBaseFormatDescriptor& formatDescriptor, CBaseD
       case EGPS:
           return CAsterixGPSSubformat::WritePacket(formatDescriptor, device, discard);//TODO
       case EXML:
-      {
-			static bool firstTime = true;
-
-			if (firstTime)
-			{
-			  strPacketDescription = "<ASTERIXSTART>";
-			  firstTime = false;
-			}
-      }
-      /* no break */
-      case EXMLLines:
+      case EXMLH:
       case EJSON:
       case EJSONH:
       case ETxt:
@@ -175,7 +165,7 @@ bool CAsterixFormat::ProcessPacket(CBaseFormatDescriptor& formatDescriptor, CBas
         return CAsterixGPSSubformat::ProcessPacket(formatDescriptor, device, discard);
       case ETxt:
       case EXML:
-      case EXMLLines:
+      case EXMLH:
       case EJSON:
       case EJSONH:
       case EOut:
@@ -210,7 +200,7 @@ bool CAsterixFormat::HeartbeatProcessing(
         return CAsterixGPSSubformat::Heartbeat(formatDescriptor, device);
     case ETxt:
     case EXML:
-    case EXMLLines:
+    case EXMLH:
     case EJSON:
     case EJSONH:
     case EOut:

--- a/src/asterix/asterixformat.cxx
+++ b/src/asterix/asterixformat.cxx
@@ -46,6 +46,7 @@ const char* CAsterixFormat::_FormatName[CAsterixFormat::ETotalFormats] =
   "ASTERIX_TXT",
   "ASTERIX_FINAL",
   "ASTERIX_XML",
+  "ASTERIX_XML_LINES",
   "ASTERIX_JSON",
   "ASTERIX_JSONH",
   "ASTERIX_HDLC",
@@ -77,6 +78,7 @@ bool CAsterixFormat::ReadPacket(CBaseFormatDescriptor& formatDescriptor, CBaseDe
       case EGPS:
           return CAsterixGPSSubformat::ReadPacket(formatDescriptor, device, discard);
       case EXML:
+      case EXMLLines:
       case EJSON:
       case EJSONH:
           //todo not supported
@@ -119,6 +121,7 @@ bool CAsterixFormat::WritePacket(CBaseFormatDescriptor& formatDescriptor, CBaseD
 			}
       }
       /* no break */
+      case EXMLLines:
       case EJSON:
       case EJSONH:
       case ETxt:
@@ -172,6 +175,7 @@ bool CAsterixFormat::ProcessPacket(CBaseFormatDescriptor& formatDescriptor, CBas
         return CAsterixGPSSubformat::ProcessPacket(formatDescriptor, device, discard);
       case ETxt:
       case EXML:
+      case EXMLLines:
       case EJSON:
       case EJSONH:
       case EOut:
@@ -206,6 +210,7 @@ bool CAsterixFormat::HeartbeatProcessing(
         return CAsterixGPSSubformat::Heartbeat(formatDescriptor, device);
     case ETxt:
     case EXML:
+    case EXMLLines:
     case EJSON:
     case EJSONH:
     case EOut:

--- a/src/asterix/asterixformat.hxx
+++ b/src/asterix/asterixformat.hxx
@@ -48,7 +48,7 @@ public:
   EPcap,          // PCAP file format
   ETxt,           // textual output (human readable)
   EFinal,         // Final format
-  EXML,           // XML
+  EXML,           // XML format, human readable form
   EXMLLines,      // Line-delimited XML (one record per line, suitable for parsing)
   EJSON,          // JSON (JavaScript Object Notation) format, compact form
   EJSONH,         // JSON (JavaScript Object Notation) format, human readable form

--- a/src/asterix/asterixformat.hxx
+++ b/src/asterix/asterixformat.hxx
@@ -49,6 +49,7 @@ public:
   ETxt,           // textual output (human readable)
   EFinal,         // Final format
   EXML,           // XML
+  EXMLLines,      // Line-delimited XML (one record per line, suitable for parsing)
   EJSON,          // JSON (JavaScript Object Notation) format, compact form
   EJSONH,         // JSON (JavaScript Object Notation) format, human readable form
   EHDLC,          // HDLC format

--- a/src/asterix/asterixformat.hxx
+++ b/src/asterix/asterixformat.hxx
@@ -48,10 +48,10 @@ public:
   EPcap,          // PCAP file format
   ETxt,           // textual output (human readable)
   EFinal,         // Final format
-  EXML,           // XML format, human readable form
-  EXMLLines,      // Line-delimited XML (one record per line, suitable for parsing)
-  EJSON,          // JSON (JavaScript Object Notation) format, compact form
-  EJSONH,         // JSON (JavaScript Object Notation) format, human readable form
+  EXML,           // XML (Extensible Markup Language) format, compact line-delimited form (suitable for parsing)
+  EXMLH,          // XML (Extensible Markup Language) format, human readable form (suitable for file storage)
+  EJSON,          // JSON (JavaScript Object Notation) format, compact line-delimited form (suitable for parsing)
+  EJSONH,         // JSON (JavaScript Object Notation) format, human readable form (suitable for file storage)
   EHDLC,          // HDLC format
   EOradisRaw,     // Raw Asterix format with ORADIS header
   EOradisPcap,    // PCAP file format with ORADIS header

--- a/src/main/asterix.cpp
+++ b/src/main/asterix.cpp
@@ -79,6 +79,7 @@ static void show_usage(std::string name)
 			  << "\n------------"
 			  << "\n\t-l,--line\tOutput will be printed as one line per item. This format is suitable for parsing."
 			  << "\n\t-x,--xml\tOutput will be printed in XML format."
+			  << "\n\t-xl,--xmllines\tOutput will be printed in line-delimited XML format (one record per line, suitable for parsing)."
 			  << "\n\t-j,--json\tOutput will be printed in compact JSON format (one object per line)."
 			  << "\n\t-jh,--jsonh\tOutput will be printed in human readable JSON format (one item per line)."
 			  << "\n\nData source"
@@ -205,6 +206,15 @@ int main(int argc, const char *argv[])
 				return 1;
 			}
 			strOutputFormat = "ASTERIX_XML";
+		}
+		else if ((arg == "-xl") || (arg == "--xmllines"))
+		{
+			if (strOutputFormat != "ASTERIX_TXT")
+			{
+				std::cerr << "Error: Option -xl not allowed because output format already defined as "+strOutputFormat << std::endl;
+				return 1;
+			}
+			strOutputFormat = "ASTERIX_XML_LINES";
 		}
 		else if ((arg == "-j") || (arg == "--json"))
 		{

--- a/src/main/asterix.cpp
+++ b/src/main/asterix.cpp
@@ -78,10 +78,10 @@ static void show_usage(std::string name)
 			  << "\n\nOutput format"
 			  << "\n------------"
 			  << "\n\t-l,--line\tOutput will be printed as one line per item. This format is suitable for parsing."
-			  << "\n\t-x,--xml\tOutput will be printed in human readable XML format."
-			  << "\n\t-xl,--xmllines\tOutput will be printed in line-delimited XML format (one record per line, suitable for parsing)."
-			  << "\n\t-j,--json\tOutput will be printed in compact JSON format (one object per line)."
-			  << "\n\t-jh,--jsonh\tOutput will be printed in human readable JSON format (one item per line)."
+			  << "\n\t-x,--xml\tOutput will be printed in compact line-delimited XML format (one object per line, suitable for parsing)."
+			  << "\n\t-xh,--xmlh\tOutput will be printed in human readable XML format (suitable for file storage)."
+			  << "\n\t-j,--json\tOutput will be printed in compact line-delimited JSON format (one object per line, suitable for parsing)."
+			  << "\n\t-jh,--jsonh\tOutput will be printed in human readable JSON format (suitable for file storage)."
 			  << "\n\nData source"
 			  << "\n------------"
 			  << "\n\t-f filename\tFile generated from libpcap (tcpdump or Wireshark) or file in FINAL or HDLC format.\n\t\t\tFor example: -f filename.pcap"
@@ -207,14 +207,14 @@ int main(int argc, const char *argv[])
 			}
 			strOutputFormat = "ASTERIX_XML";
 		}
-		else if ((arg == "-xl") || (arg == "--xmllines"))
+		else if ((arg == "-xh") || (arg == "--xmlh"))
 		{
 			if (strOutputFormat != "ASTERIX_TXT")
 			{
-				std::cerr << "Error: Option -xl not allowed because output format already defined as "+strOutputFormat << std::endl;
+				std::cerr << "Error: Option -xh not allowed because output format already defined as "+strOutputFormat << std::endl;
 				return 1;
 			}
-			strOutputFormat = "ASTERIX_XML_LINES";
+			strOutputFormat = "ASTERIX_XMLH";
 		}
 		else if ((arg == "-j") || (arg == "--json"))
 		{

--- a/src/main/asterix.cpp
+++ b/src/main/asterix.cpp
@@ -78,7 +78,7 @@ static void show_usage(std::string name)
 			  << "\n\nOutput format"
 			  << "\n------------"
 			  << "\n\t-l,--line\tOutput will be printed as one line per item. This format is suitable for parsing."
-			  << "\n\t-x,--xml\tOutput will be printed in XML format."
+			  << "\n\t-x,--xml\tOutput will be printed in human readable XML format."
 			  << "\n\t-xl,--xmllines\tOutput will be printed in line-delimited XML format (one record per line, suitable for parsing)."
 			  << "\n\t-j,--json\tOutput will be printed in compact JSON format (one object per line)."
 			  << "\n\t-jh,--jsonh\tOutput will be printed in human readable JSON format (one item per line)."


### PR DESCRIPTION
Lately, I have been working on a parser that reads the ASTERIX XML output (`--xml` option) and, motivated by some difficulties I faced and taking into consideration what was discussed in PR #108, I have come to the conclusion that this software would benefit from having a stream-oriented version of XML where each ASTERIX Record is printed on a separate line, hence a line-delimited XML format.

Based on what I have found online, the _"one object per line"_ framing strategy is common practice when communicating processes that speak JSON or XML. This is specially true for JSON, where several line-delimited specifications exist like [JSON Lines](http://jsonlines.org/) and [Newline Delimited JSON](http://ndjson.org/).

In this PR, I have added said line-delimited XML format to the list of available output formats and can be activated by passing the `-xl` or `--xmllines` flags. The output looks like this:

```
$ ./asterix --xmllines -f ../asterix/sample_data/cat062cat065.raw

<ASTERIX ver="1" length="66" crc="2D483649" timestamp="45772255" hexdata="3E0045BFCFFD021964043C5FD5007F3E9B0025188DF8B42AFCC2FCFF3302A8000008BE137411030118701D00FF2890000002741B100274FFB9DC190DBAB0B880027408BE40" cat="62"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.6640625</ToT></I070><I105><Lat>44.7344130</Lat><Lon>13.0415279</Lon></I105><I100><X>-239083.0000000</X><Y>-106114.0000000</Y></I100><I185><Vx>-51.2500000</Vx><Vy>170.0000000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>4276</Mode3A></I060><I040><TrkN>4980</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>4</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>0</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>1</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>7.2500000</PSR><SSR>0.0000000</SSR><MDS>63.7500000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>2</LONGA><VERTA>2</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>15700.0000000</MFL></I136><I130><Alt>43300.0000000</Alt></I130><I135><QNH>0</QNH><CTBA>15700.0000000</CTBA></I135><I220><RoC>-443.7500000</RoC></I220><I340><SAC>25</SAC><SIC>13</SIC><RHO>186.6875000</RHO><THETA>259.4531250</THETA><CV>0</CV><CG>0</CG><ModeC>157.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>4276</Mode3A><TYP>2</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" length="114" crc="9B67161C" timestamp="45772255" hexdata="3E0075BFDFFF021964043C5FEA008123DC002B0BA6FDC917FEE5EB0236FD550000055DC1203C0A554D8134DF2CE020F61F290D13010870040000009000000578161205780000FFE10019645358443437323341BE122D44423733384D4544444C48454C582000200578DC190D5D32C10B0578055DA0" cat="62"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.8281250</ToT></I070><I105><Lat>45.4008079</Lat><Lon>15.1331842</Lon></I105><I100><X>-72564.5000000</X><Y>-36106.5000000</Y></I100><I185><Vx>141.5000000</Vx><Vy>-170.7500000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>2535</Mode3A></I060><I380><ADR>3C0A55</ADR><ACID>SXD4723 </ACID><COM>1</COM><STAT>0</STAT><spare>0</spare><SSC>1</SSC><ARC>1</ARC><AIC>1</AIC><B1A>1</B1A><B1B>6</B1B></I380><I040><TrkN>7977</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>3</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>1</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>0</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>1.0000000</PSR><SSR>0.0000000</SSR><MDS>0.0000000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>0</LONGA><VERTA>0</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>35000.0000000</MFL></I136><I130><Alt>35312.5000000</Alt></I130><I135><QNH>0</QNH><CTBA>35000.0000000</CTBA></I135><I220><RoC>0.0000000</RoC></I220><I390><SAC>25</SAC><SIC>100</SIC><CS></CS><TYP>1</TYP><spare>0</spare><NBR>29233709</NBR><GATOAT>1</GATOAT><FR1FR2>0</FR1FR2><RVSM>1</RVSM><HPR>0</HPR><spare>0</spare><TYPE></TYPE><WTC></WTC><DEP></DEP><DES></DES><NU1></NU1><NU2></NU2><LTR></LTR><CFL>350.0000000</CFL></I390><I340><SAC>25</SAC><SIC>13</SIC><RHO>93.1953125</RHO><THETA>271.4666748</THETA><CV>0</CV><CG>0</CG><ModeC>350.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>2535</Mode3A><TYP>5</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" length="9" crc="D6C0E322" timestamp="45772255" hexdata="41000CF8196402043C608718" cat="65"><I010><SAC>25</SAC><SIC>100</SIC></I010><I000><Typ>2</Typ></I000><I015><SID>4</SID></I015><I030><ToD>30913.0546875</ToD></I030><I020><BTN>24</BTN></I020></ASTERIX>
```

Notice that, for convenience, I have deliberately omitted the [`<ASTERIXSTART>`](https://github.com/CroatiaControlLtd/asterix/blob/7dc555249a92881f29349dda54013473d2dfdb57/src/asterix/asterixformat.cxx#L117) element that is printed at the beginning of the `--xml` output format.

Now, in order to emphasize the differences between the existing `--xml` format and the new `--xmllines` format, I have added the missing indents to the former, so it is now easier to tell apart each Data Item and its contents. I tend to use spaces over of tabs (unlike `--jsonh`) to avoid the issue of different editor programs treating tabs differently. Here is how the `--xml` output looks like now:

```
$ ./asterix --xml -f ../asterix/sample_data/cat048.raw 

<ASTERIXSTART>
  <ASTERIX ver="1" length="45" crc="E2693598" timestamp="46952552" hexdata="300030FDF70219C9356D4DA0C5AFF1E0020005283C660C10C236D4182001C0780031BC0000400DEB07B9582E410020F5" cat="48">
    <I010>
      <SAC>25</SAC>
      <SIC>201</SIC>
    </I010>
    <I140>
      <ToD>27354.6015625</ToD>
    </I140>
    <I020>
      <TYP>5</TYP>
      <SIM>0</SIM>
      <RDP>0</RDP>
      <SPI>0</SPI>
      <RAB>0</RAB>
      <FX>0</FX>
    </I020>
    <I040>
      <RHO>197.6835938</RHO>
      <THETA>340.1367188</THETA>
    </I040>
    <I070>
      <V>0</V>
      <G>0</G>
      <L>0</L>
      <spare>0</spare>
      <Mode3A>1000</Mode3A>
    </I070>
    <I090>
      <V>0</V>
      <G>0</G>
      <FL>330.0000000</FL>
    </I090>
    <I220>
      <ACAddr>3C660C</ACAddr>
    </I220>
    <I240>
      <TId>DLH65A  </TId>
    </I240>
    <I250>
      <MCP_ALT_STATUS>1</MCP_ALT_STATUS>
      <MCP_ALT>33008.0000000</MCP_ALT>
      <FMS_ALT_STATUS>0</FMS_ALT_STATUS>
      <FMS_ALT>0.0000000</FMS_ALT>
      <BP_STATUS>1</BP_STATUS>
      <BP>227.0000000</BP>
      <res>0</res>
      <MODE_STATUS>0</MODE_STATUS>
      <VNAV>0</VNAV>
      <ALT_HOLD>0</ALT_HOLD>
      <APP>0</APP>
      <res>0</res>
      <TARGET_ALT_STATUS>0</TARGET_ALT_STATUS>
      <TARGET_ALT_SOURCE>0</TARGET_ALT_SOURCE>
      <BDS>40</BDS>
    </I250>
    <I161>
      <Tn>3563</Tn>
    </I161>
    <I200>
      <CGS>434.9400000</CGS>
      <CHdg>124.0026855</CHdg>
    </I200>
    <I170>
      <CNF>0</CNF>
      <RAD>2</RAD>
      <DOU>0</DOU>
      <MAH>0</MAH>
      <CDM>0</CDM>
      <FX>1</FX>
      <TRE>0</TRE>
      <GHO>0</GHO>
      <SUP>0</SUP>
      <TCC>0</TCC>
      <spare>0</spare>
      <FX>0</FX>
    </I170>
    <I230>
      <COM>1</COM>
      <STAT>0</STAT>
      <SI>0</SI>
      <spare>0</spare>
      <ModeSSSC>1</ModeSSSC>
      <ARC>1</ARC>
      <AIC>1</AIC>
      <BDS16>1</BDS16>
      <BDS37>5</BDS37>
    </I230>
  </ASTERIX>
```

The missing `</ASTERIXSTART>` closing tag issue still remains unsolved...