### PR TITLE
Print cat attribute before the length in XML outputs

### DIFF
--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -202,8 +202,8 @@ bool DataRecord::getText(std::string &strResult, std::string &strHeader, const u
         case CAsterixFormat::EXMLH: {
             const int nXIDEFv = 1;
             strNewResult = format(
-                    "<ASTERIX ver=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\" cat=\"%d\">",
-                    nXIDEFv, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+                    "<ASTERIX ver=\"%d\" cat=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\">",
+                    nXIDEFv, m_pCategory->m_id, m_nLength, m_nCrc, m_nTimestamp, m_pHexData);
             break;
         }
     }


### PR DESCRIPTION
This PR makes a minor cosmetic change to the XML output formats (this applies to both the line-delimited and human readable formats).

Currently, the `cat` attribute is printed after the `hexdata` attribute, which makes it a little bit hard to tell apart the ASTERIX category of each record when performing a visual inspection of the output. Therefore I have moved `cat` to the beginning of the attribute list, right before the `length`, resembling the natural order in which both fields are defined in the [ASTERIX Specification](https://www.eurocontrol.int/sites/default/files/2019-06/part_1_-_eurocontrol_specification_asterix_spec-149_ed_2.4.pdf).

Before:

```
$ ./asterix -x -f ../../install/sample_data/cat062cat065.raw

<ASTERIX ver="1" length="66" crc="2D483649" timestamp="67185373" hexdata="3E0045BFCFFD021964043C5FD5007F3E9B0025188DF8B42AFCC2FCFF3302A8000008BE137411030118701D00FF2890000002741B100274FFB9DC190DBAB0B880027408BE40" cat="62"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.6640625</ToT></I070><I105><Lat>44.7344130</Lat><Lon>13.0415279</Lon></I105><I100><X>-239083.0000000</X><Y>-106114.0000000</Y></I100><I185><Vx>-51.2500000</Vx><Vy>170.0000000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>4276</Mode3A></I060><I040><TrkN>4980</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>4</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>0</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>1</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>7.2500000</PSR><SSR>0.0000000</SSR><MDS>63.7500000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>2</LONGA><VERTA>2</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>15700.0000000</MFL></I136><I130><Alt>43300.0000000</Alt></I130><I135><QNH>0</QNH><CTBA>15700.0000000</CTBA></I135><I220><RoC>-443.7500000</RoC></I220><I340><SAC>25</SAC><SIC>13</SIC><RHO>186.6875000</RHO><THETA>259.4531250</THETA><CV>0</CV><CG>0</CG><ModeC>157.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>4276</Mode3A><TYP>2</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" length="114" crc="9B67161C" timestamp="67185373" hexdata="3E0075BFDFFF021964043C5FEA008123DC002B0BA6FDC917FEE5EB0236FD550000055DC1203C0A554D8134DF2CE020F61F290D13010870040000009000000578161205780000FFE10019645358443437323341BE122D44423733384D4544444C48454C582000200578DC190D5D32C10B0578055DA0" cat="62"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.8281250</ToT></I070><I105><Lat>45.4008079</Lat><Lon>15.1331842</Lon></I105><I100><X>-72564.5000000</X><Y>-36106.5000000</Y></I100><I185><Vx>141.5000000</Vx><Vy>-170.7500000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>2535</Mode3A></I060><I380><ADR>3C0A55</ADR><ACID>SXD4723 </ACID><COM>1</COM><STAT>0</STAT><spare>0</spare><SSC>1</SSC><ARC>1</ARC><AIC>1</AIC><B1A>1</B1A><B1B>6</B1B></I380><I040><TrkN>7977</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>3</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>1</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>0</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>1.0000000</PSR><SSR>0.0000000</SSR><MDS>0.0000000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>0</LONGA><VERTA>0</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>35000.0000000</MFL></I136><I130><Alt>35312.5000000</Alt></I130><I135><QNH>0</QNH><CTBA>35000.0000000</CTBA></I135><I220><RoC>0.0000000</RoC></I220><I390><SAC>25</SAC><SIC>100</SIC><CS></CS><TYP>1</TYP><spare>0</spare><NBR>29233709</NBR><GATOAT>1</GATOAT><FR1FR2>0</FR1FR2><RVSM>1</RVSM><HPR>0</HPR><spare>0</spare><TYPE></TYPE><WTC></WTC><DEP></DEP><DES></DES><NU1></NU1><NU2></NU2><LTR></LTR><CFL>350.0000000</CFL></I390><I340><SAC>25</SAC><SIC>13</SIC><RHO>93.1953125</RHO><THETA>271.4666748</THETA><CV>0</CV><CG>0</CG><ModeC>350.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>2535</Mode3A><TYP>5</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" length="9" crc="D6C0E322" timestamp="67185373" hexdata="41000CF8196402043C608718" cat="65"><I010><SAC>25</SAC><SIC>100</SIC></I010><I000><Typ>2</Typ></I000><I015><SID>4</SID></I015><I030><ToD>30913.0546875</ToD></I030><I020><BTN>24</BTN></I020></ASTERIX>
```

After:

```
$ ./asterix -x -f ../../install/sample_data/cat062cat065.raw

<ASTERIX ver="1" cat="62" length="66" crc="2D483649" timestamp="66923597" hexdata="3E0045BFCFFD021964043C5FD5007F3E9B0025188DF8B42AFCC2FCFF3302A8000008BE137411030118701D00FF2890000002741B100274FFB9DC190DBAB0B880027408BE40"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.6640625</ToT></I070><I105><Lat>44.7344130</Lat><Lon>13.0415279</Lon></I105><I100><X>-239083.0000000</X><Y>-106114.0000000</Y></I100><I185><Vx>-51.2500000</Vx><Vy>170.0000000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>4276</Mode3A></I060><I040><TrkN>4980</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>4</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>0</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>1</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>7.2500000</PSR><SSR>0.0000000</SSR><MDS>63.7500000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>2</LONGA><VERTA>2</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>15700.0000000</MFL></I136><I130><Alt>43300.0000000</Alt></I130><I135><QNH>0</QNH><CTBA>15700.0000000</CTBA></I135><I220><RoC>-443.7500000</RoC></I220><I340><SAC>25</SAC><SIC>13</SIC><RHO>186.6875000</RHO><THETA>259.4531250</THETA><CV>0</CV><CG>0</CG><ModeC>157.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>4276</Mode3A><TYP>2</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" cat="62" length="114" crc="9B67161C" timestamp="66923597" hexdata="3E0075BFDFFF021964043C5FEA008123DC002B0BA6FDC917FEE5EB0236FD550000055DC1203C0A554D8134DF2CE020F61F290D13010870040000009000000578161205780000FFE10019645358443437323341BE122D44423733384D4544444C48454C582000200578DC190D5D32C10B0578055DA0"><I010><SAC>25</SAC><SIC>100</SIC></I010><I015><SID>4</SID></I015><I070><ToT>30911.8281250</ToT></I070><I105><Lat>45.4008079</Lat><Lon>15.1331842</Lon></I105><I100><X>-72564.5000000</X><Y>-36106.5000000</Y></I100><I185><Vx>141.5000000</Vx><Vy>-170.7500000</Vy></I185><I210><Ax>0.0000000</Ax><Ay>0.0000000</Ay></I210><I060><V>0</V><G>0</G><CH>0</CH><spare>0</spare><Mode3A>2535</Mode3A></I060><I380><ADR>3C0A55</ADR><ACID>SXD4723 </ACID><COM>1</COM><STAT>0</STAT><spare>0</spare><SSC>1</SSC><ARC>1</ARC><AIC>1</AIC><B1A>1</B1A><B1B>6</B1B></I380><I040><TrkN>7977</TrkN></I040><I080><MON>0</MON><SPI>0</SPI><MRH>0</MRH><SRC>3</SRC><CNF>0</CNF><FX>1</FX><SIM>0</SIM><TSE>0</TSE><TSB>0</TSB><FPC>1</FPC><AFF>0</AFF><STP>0</STP><KOS>1</KOS><FX>1</FX><AMA>0</AMA><MD4>0</MD4><ME>0</ME><MI>0</MI><MD5>0</MD5><FX>1</FX><CST>0</CST><PSR>0</PSR><SSR>0</SSR><MDS>0</MDS><ADS>1</ADS><SUC>0</SUC><AAC>0</AAC><FX>0</FX></I080><I290><PSR>1.0000000</PSR><SSR>0.0000000</SSR><MDS>0.0000000</MDS></I290><I200><TRANSA>0</TRANSA><LONGA>0</LONGA><VERTA>0</VERTA><ADF>0</ADF><spare>0</spare></I200><I295><MFL>0.0000000</MFL><MDA>0.0000000</MDA></I295><I136><MFL>35000.0000000</MFL></I136><I130><Alt>35312.5000000</Alt></I130><I135><QNH>0</QNH><CTBA>35000.0000000</CTBA></I135><I220><RoC>0.0000000</RoC></I220><I390><SAC>25</SAC><SIC>100</SIC><CS></CS><TYP>1</TYP><spare>0</spare><NBR>29233709</NBR><GATOAT>1</GATOAT><FR1FR2>0</FR1FR2><RVSM>1</RVSM><HPR>0</HPR><spare>0</spare><TYPE></TYPE><WTC></WTC><DEP></DEP><DES></DES><NU1></NU1><NU2></NU2><LTR></LTR><CFL>350.0000000</CFL></I390><I340><SAC>25</SAC><SIC>13</SIC><RHO>93.1953125</RHO><THETA>271.4666748</THETA><CV>0</CV><CG>0</CG><ModeC>350.0000000</ModeC><V>0</V><G>0</G><L>0</L><spare>0</spare><Mode3A>2535</Mode3A><TYP>5</TYP><SIM>0</SIM><RAB>0</RAB><TST>0</TST><spare>0</spare></I340></ASTERIX>
<ASTERIX ver="1" cat="65" length="9" crc="D6C0E322" timestamp="66923597" hexdata="41000CF8196402043C608718"><I010><SAC>25</SAC><SIC>100</SIC></I010><I000><Typ>2</Typ></I000><I015><SID>4</SID></I015><I030><ToD>30913.0546875</ToD></I030><I020><BTN>24</BTN></I020></ASTERIX>
```

This way, it is easier to spot the category information at a glance.