### PR TITLE
asterix.describeXML returns lxml.Etree from parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *~
 /cmake-build-debug/
 /.idea/
+**.pyc

--- a/asterix/__init__.py
+++ b/asterix/__init__.py
@@ -185,11 +185,12 @@ def describeXML(parsed):
 
         xml_Items = etree.SubElement(xml_Record, 'Items')
         for key, value in record.items():
-            if key != 'category':
+            if key[0] == 'I':
                 xml_Item = etree.SubElement(xml_Items, 'Item')
                 xml_Item.set('id', '%s' % str(key))
-                xml_Item.set('description',
-                             '%s' % _asterix.describe(cat, str(key)))
+                description = '%s' % _asterix.describe(cat, str(key))
+                if description:
+                    xml_Item.set('description', description)
                 if isinstance(value, dict):
                     for ikey, ival in value.items():
                         xml_Field = etree.SubElement(xml_Item, 'Field')


### PR DESCRIPTION
New function describeXML returns a [lxml](https://lxml.de/tutorial.html) ElementTree. Example:
```
import lxml
import asterix

rawdata =  open(asterix.get_sample_file('cat062cat065.raw'), 'rb').read()
result = asterix.parse(rawdata)
xml = asterix.describeXML(result)

strxml = lxml.etree.tostring(xml, pretty_print=True)
print(strxml)
```