### PR TITLE
add hexdata key to DataRecord

### DIFF
--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -369,6 +369,12 @@ PyObject* DataRecord::getData(int verbose)
     Py_DECREF(k4);
     Py_DECREF(v4);
 
+    PyObject* k5 = Py_BuildValue("s", "hexdata");
+    PyObject* v5 = Py_BuildValue("s", m_pHexData);
+    PyDict_SetItem(p, k5, v5);
+    Py_DECREF(k5);
+    Py_DECREF(v5);
+
     if (m_bFormatOK)
     {
         // go through all present data items in this record


### PR DESCRIPTION
Add attribute hexdata missing from branch develop/describeXML merged in pull request #137 .