### PR TITLE
RE item definition and minor fixes

### DIFF
--- a/asterix-specs-converter/README.md
+++ b/asterix-specs-converter/README.md
@@ -3,7 +3,7 @@
 This directory contains a script to convert asterix definitions from .json to .xml format.
 
 Original asterix definition files are currently stored as .ast files
-(custom syntax) in this project: 
+(custom syntax) in this project:
 
 https://github.com/zoranbosnjak/asterix-specs
 
@@ -30,14 +30,14 @@ To run the script inside nix environment:
 ```bash
 nix-shell -p python38
 python3 --version
-python3 json-to-xml.py {input.json}
+python3 json-to-xml.py < input.json
 # or
-curl https://zoranbosnjak.github.io/asterix-specs/specs/cat062/v1.18/cat062-v1.18.json | python3 json-to-xml.py
+curl https://zoranbosnjak.github.io/asterix-specs/specs/cat062/cats/cat1.18/definition.json | python3 json-to-xml.py
 ```
 
-To convert multiple json files:
+To combine CAT+REF definition:
 
 ```bash
-for i in $(ls | grep "\.json$"); do echo $i && python3 json-to-xml.py $i > $i.generated.xml; done
+python3 json-to-xml.py --cat category.json --ref ref.json --outfile out.xml
 ```
 

--- a/asterix-specs-converter/asterix_cat011_1_2_generated.xml
+++ b/asterix-specs-converter/asterix_cat011_1_2_generated.xml
@@ -6,7 +6,7 @@
     Asterix Category 011 v1.2 definition
 
     This file is auto-generated from json specs file.
-    sha1sum of the json input: c5ff35774a854c33782f764c98f676aa652cbdfa
+    sha1sum of concatinated json input(s): 91de78cefa11077dbfb872ec5755111d9ad3d1d8
 -->
 
 <Category id="11" name="Transmission of A-SMGCS Data" ver="1.2">
@@ -1172,10 +1172,10 @@
                     <Bits from="8" to="1">
                         <BitsShortName>WTC</BitsShortName>
                         <BitsName>Wake Turbulence Category</BitsName>
-                        <BitsValue val="76">Light</BitsValue>
-                        <BitsValue val="77">Medium</BitsValue>
                         <BitsValue val="72">Heavy</BitsValue>
                         <BitsValue val="74">Super</BitsValue>
+                        <BitsValue val="76">Light</BitsValue>
+                        <BitsValue val="77">Medium</BitsValue>
                     </Bits>
                 </Fixed>
 
@@ -1619,7 +1619,13 @@
             Special Purpose Field
         </DataItemDefinition>
         <DataItemFormat desc="Explicit data item.">
-            <Explicit/>
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>LEN</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
         </DataItemFormat>
     </DataItem>
 
@@ -1629,7 +1635,13 @@
             Expansion
         </DataItemDefinition>
         <DataItemFormat desc="Explicit data item.">
-            <Explicit/>
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>LEN</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
         </DataItemFormat>
     </DataItem>
 

--- a/asterix-specs-converter/asterix_cat011_1_3_generated.xml
+++ b/asterix-specs-converter/asterix_cat011_1_3_generated.xml
@@ -6,7 +6,7 @@
     Asterix Category 011 v1.3 definition
 
     This file is auto-generated from json specs file.
-    sha1sum of the json input: d98830512cd7ead8533d55c4b3349b06c8b5f41b
+    sha1sum of concatinated json input(s): 2971e4660a700575747c560bf5a8256306f43ff1
 -->
 
 <Category id="11" name="Transmission of A-SMGCS Data" ver="1.3">
@@ -1172,10 +1172,10 @@
                     <Bits from="8" to="1">
                         <BitsShortName>WTC</BitsShortName>
                         <BitsName>Wake Turbulence Category</BitsName>
-                        <BitsValue val="76">Light</BitsValue>
-                        <BitsValue val="77">Medium</BitsValue>
                         <BitsValue val="72">Heavy</BitsValue>
                         <BitsValue val="74">Super</BitsValue>
+                        <BitsValue val="76">Light</BitsValue>
+                        <BitsValue val="77">Medium</BitsValue>
                     </Bits>
                 </Fixed>
 
@@ -1619,7 +1619,13 @@
             Special Purpose Field
         </DataItemDefinition>
         <DataItemFormat desc="Explicit data item.">
-            <Explicit/>
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>LEN</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
         </DataItemFormat>
     </DataItem>
 
@@ -1629,7 +1635,13 @@
             Expansion
         </DataItemDefinition>
         <DataItemFormat desc="Explicit data item.">
-            <Explicit/>
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>LEN</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
         </DataItemFormat>
     </DataItem>
 

--- a/asterix-specs-converter/asterix_cat021_2_4-1_4_generated.xml
+++ b/asterix-specs-converter/asterix_cat021_2_4-1_4_generated.xml
@@ -1,0 +1,2279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Category SYSTEM "asterix.dtd">
+
+<!--
+
+    Asterix Category 021 v2.4 definition
+
+    This file is auto-generated from json specs file.
+    sha1sum of concatinated json input(s): 65cd69b7c704facd7f9240b43e19f6078646403a
+-->
+
+<Category id="21" name="ADS-B Target Reports" ver="2.4">
+
+    <DataItem id="008">
+        <DataItemName>Aircraft Operational Status</DataItemName>
+        <DataItemDefinition>
+            Identification of the operational services available in the aircraft
+            while airborne.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>RA</BitsShortName>
+                    <BitsName>TCAS Resolution Advisory active</BitsName>
+                    <BitsValue val="0">TCAS II or ACAS RA not active</BitsValue>
+                    <BitsValue val="1">TCAS RA active</BitsValue>
+                </Bits>
+                <Bits from="7" to="6">
+                    <BitsShortName>TC</BitsShortName>
+                    <BitsName>Target Trajectory Change Report Capability</BitsName>
+                    <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
+                    <BitsValue val="1">support for TC+0 reports only</BitsValue>
+                    <BitsValue val="2">support for multiple TC reports</BitsValue>
+                    <BitsValue val="3">reserved</BitsValue>
+                </Bits>
+                <Bits bit="5">
+                    <BitsShortName>TS</BitsShortName>
+                    <BitsName>Target State Report Capability</BitsName>
+                    <BitsValue val="0">no capability to support Target State Reports</BitsValue>
+                    <BitsValue val="1">capable of supporting target State Reports</BitsValue>
+                </Bits>
+                <Bits bit="4">
+                    <BitsShortName>ARV</BitsShortName>
+                    <BitsName>Air-Referenced Velocity Report Capability</BitsName>
+                    <BitsValue val="0">no capability to generate ARV-reports</BitsValue>
+                    <BitsValue val="1">capable of generate ARV-reports</BitsValue>
+                </Bits>
+                <Bits bit="3">
+                    <BitsShortName>CDTI_A</BitsShortName>
+                    <BitsName>Cockpit Display of Traffic Information airborne</BitsName>
+                    <BitsValue val="0">CDTI not operational</BitsValue>
+                    <BitsValue val="1">CDTI operational</BitsValue>
+                </Bits>
+                <Bits bit="2">
+                    <BitsShortName>NOTTCAS</BitsShortName>
+                    <BitsName>TCAS System Status</BitsName>
+                    <BitsValue val="0">TCAS operational</BitsValue>
+                    <BitsValue val="1">TCAS not operational</BitsValue>
+                </Bits>
+                <Bits bit="1">
+                    <BitsShortName>SA</BitsShortName>
+                    <BitsName>Single Antenna</BitsName>
+                    <BitsValue val="0">Antenna Diversity</BitsValue>
+                    <BitsValue val="1">Single Antenna only</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="010">
+        <DataItemName>Data Source Identification</DataItemName>
+        <DataItemDefinition>
+            Identification of the ADS-B station providing information.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="9">
+                    <BitsShortName>SAC</BitsShortName>
+                    <BitsName>System Area Code</BitsName>
+                </Bits>
+                <Bits from="8" to="1">
+                    <BitsShortName>SIC</BitsShortName>
+                    <BitsName>System Identification code</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="015">
+        <DataItemName>Service Identification</DataItemName>
+        <DataItemDefinition>
+            Identification of the service provided to one or more users.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>id</BitsShortName>
+                    <BitsName>Service Identification</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="016">
+        <DataItemName>Service Management</DataItemName>
+        <DataItemDefinition>
+            Identification of services offered by a ground station (identified by a SIC code).
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1" encode="unsigned">
+                    <BitsShortName>016</BitsShortName>
+                    <BitsName>Service Management</BitsName>
+                    <BitsUnit scale="0.5">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="020">
+        <DataItemName>Emitter Category</DataItemName>
+        <DataItemDefinition>
+            Characteristics of the originating ADS-B unit.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>ECAT</BitsShortName>
+                    <BitsName>Emitter Category</BitsName>
+                    <BitsValue val="0">No ADS-B Emitter Category Information</BitsValue>
+                    <BitsValue val="1">light aircraft &lt;= 15500 lbs</BitsValue>
+                    <BitsValue val="2">15500 lbs &lt; small aircraft &lt;75000 lbs</BitsValue>
+                    <BitsValue val="3">75000 lbs &lt; medium a/c &lt; 300000 lbs</BitsValue>
+                    <BitsValue val="4">High Vortex Large</BitsValue>
+                    <BitsValue val="5">300000 lbs &lt;= heavy aircraft</BitsValue>
+                    <BitsValue val="6">highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise)</BitsValue>
+                    <BitsValue val="7">reserved</BitsValue>
+                    <BitsValue val="8">reserved</BitsValue>
+                    <BitsValue val="9">reserved</BitsValue>
+                    <BitsValue val="10">rotocraft</BitsValue>
+                    <BitsValue val="11">glider / sailplane</BitsValue>
+                    <BitsValue val="12">lighter-than-air</BitsValue>
+                    <BitsValue val="13">unmanned aerial vehicle</BitsValue>
+                    <BitsValue val="14">space / transatmospheric vehicle</BitsValue>
+                    <BitsValue val="15">ultralight / handglider / paraglider</BitsValue>
+                    <BitsValue val="16">parachutist / skydiver</BitsValue>
+                    <BitsValue val="17">reserved</BitsValue>
+                    <BitsValue val="18">reserved</BitsValue>
+                    <BitsValue val="19">reserved</BitsValue>
+                    <BitsValue val="20">surface emergency vehicle</BitsValue>
+                    <BitsValue val="21">surface service vehicle</BitsValue>
+                    <BitsValue val="22">fixed ground or tethered obstruction</BitsValue>
+                    <BitsValue val="23">cluster obstacle</BitsValue>
+                    <BitsValue val="24">line obstacle</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="040">
+        <DataItemName>Target Report Descriptor</DataItemName>
+        <DataItemDefinition>
+            Type and characteristics of the data as transmitted by a system.
+        </DataItemDefinition>
+        <DataItemFormat desc="Variable data item.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>ATP</BitsShortName>
+                        <BitsName>Address Type</BitsName>
+                        <BitsValue val="0">24-Bit ICAO address</BitsValue>
+                        <BitsValue val="1">Duplicate address</BitsValue>
+                        <BitsValue val="2">Surface vehicle address</BitsValue>
+                        <BitsValue val="3">Anonymous address</BitsValue>
+                        <BitsValue val="4">Reserved for future use</BitsValue>
+                        <BitsValue val="5">Reserved for future use</BitsValue>
+                        <BitsValue val="6">Reserved for future use</BitsValue>
+                        <BitsValue val="7">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>ARC</BitsShortName>
+                        <BitsName>Altitude Reporting Capability</BitsName>
+                        <BitsValue val="0">25 ft</BitsValue>
+                        <BitsValue val="1">100 ft</BitsValue>
+                        <BitsValue val="2">Unknown</BitsValue>
+                        <BitsValue val="3">Invalid</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RC</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Range Check passed, CPR Validation pending</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RAB</BitsShortName>
+                        <BitsName>Report Type</BitsName>
+                        <BitsValue val="0">Report from target transponder</BitsValue>
+                        <BitsValue val="1">Report from field monitor (fixed transponder)</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>DCR</BitsShortName>
+                        <BitsName>Differential Correction</BitsName>
+                        <BitsValue val="0">No differential correction (ADS-B)</BitsValue>
+                        <BitsValue val="1">Differential correction (ADS-B)</BitsValue>
+                    </Bits>
+                    <Bits bit="7">
+                        <BitsShortName>GBS</BitsShortName>
+                        <BitsName>Ground Bit Setting</BitsName>
+                        <BitsValue val="0">Ground Bit not set</BitsValue>
+                        <BitsValue val="1">Ground Bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SIM</BitsShortName>
+                        <BitsName>Simulated Target</BitsName>
+                        <BitsValue val="0">Actual target report</BitsValue>
+                        <BitsValue val="1">Simulated target report</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>TST</BitsShortName>
+                        <BitsName>Test Target</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Test Target</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>SAA</BitsShortName>
+                        <BitsName>Selected Altitude Available</BitsName>
+                        <BitsValue val="0">Equipment capable to provide Selected Altitude</BitsValue>
+                        <BitsValue val="1">Equipment not capable to provide Selected Altitude</BitsValue>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>CL</BitsShortName>
+                        <BitsName>Confidence Level</BitsName>
+                        <BitsValue val="0">Report valid</BitsValue>
+                        <BitsValue val="1">Report suspect</BitsValue>
+                        <BitsValue val="2">No information</BitsValue>
+                        <BitsValue val="3">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bit(s) set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="7">
+                        <BitsShortName>LLC</BitsShortName>
+                        <BitsName>List Lookup Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">List Lookup failed (see note)</BitsValue>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>IPC</BitsShortName>
+                        <BitsName>Independent Position Check</BitsName>
+                        <BitsValue val="0">default (see note)</BitsValue>
+                        <BitsValue val="1">Independent Position Check failed</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>NOGO</BitsShortName>
+                        <BitsName>No-go Bit Status</BitsName>
+                        <BitsValue val="0">NOGO-bit not set</BitsValue>
+                        <BitsValue val="1">NOGO-bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>CPR</BitsShortName>
+                        <BitsName>Compact Position Reporting</BitsName>
+                        <BitsValue val="0">CPR Validation correct</BitsValue>
+                        <BitsValue val="1">CPR Validation failed</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>LDPJ</BitsShortName>
+                        <BitsName>Local Decoding Position Jump</BitsName>
+                        <BitsValue val="0">LDPJ not detected</BitsValue>
+                        <BitsValue val="1">LDPJ detected</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RCF</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">Range Check failed</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="070">
+        <DataItemName>Mode 3/A Code in Octal Representation</DataItemName>
+        <DataItemDefinition>
+            Mode-3/A code converted into octal representation.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bit(s) set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1">
+                    <BitsShortName>ABCD</BitsShortName>
+                    <BitsName>Mode-3/A reply in octal representation</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="071">
+        <DataItemName>Time of Applicability for Position</DataItemName>
+        <DataItemDefinition>
+            Time of applicability of the reported position, in the form of elapsed
+            time since last midnight, expressed as UTC.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="unsigned">
+                    <BitsShortName>071</BitsShortName>
+                    <BitsName>Time of Applicability for Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="072">
+        <DataItemName>Time of Applicability for Velocity</DataItemName>
+        <DataItemDefinition>
+            Time of applicability (measurement) of the reported velocity, in the
+            form of elapsed time since last midnight, expressed as UTC.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="unsigned">
+                    <BitsShortName>072</BitsShortName>
+                    <BitsName>Time of Applicability for Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="073">
+        <DataItemName>Time of Message Reception for Position</DataItemName>
+        <DataItemDefinition>
+            Time of reception of the latest position squitter in the Ground Station,
+            in the form of elapsed time since last midnight, expressed as UTC.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="unsigned">
+                    <BitsShortName>073</BitsShortName>
+                    <BitsName>Time of Message Reception for Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="074">
+        <DataItemName>Time of Message Reception of Position-High Precision</DataItemName>
+        <DataItemDefinition>
+            Time at which the latest ADS-B position information was received by
+            the ground station, expressed as fraction of the second of the UTC Time.
+        </DataItemDefinition>
+        <DataItemFormat desc="4-octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRp whole seconds = (I021/073) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRp whole seconds = (I021/073) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRp whole seconds = (I021/073) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1" encode="unsigned">
+                    <BitsShortName>TOMRP</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for position in the ground station.</BitsName>
+                    <BitsUnit scale="0.00000000093132257461547851562">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="075">
+        <DataItemName>Time of Message Reception for Velocity</DataItemName>
+        <DataItemDefinition>
+            Time of reception of the latest velocity squitter in the Ground Station,
+            in the form of elapsed time since last midnight, expressed as UTC.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="unsigned">
+                    <BitsShortName>075</BitsShortName>
+                    <BitsName>Time of Message Reception for Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="076">
+        <DataItemName>Time of Message Reception of Velocity-High Precision</DataItemName>
+        <DataItemDefinition>
+            Time at which the latest ADS-B velocity information was received by
+            the ground station, expressed as fraction of the second of the UTC Time.
+        </DataItemDefinition>
+        <DataItemFormat desc="4-octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRv whole seconds = (I021/075) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRv whole seconds = (I021/075) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRv whole seconds = (I021/075) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1" encode="unsigned">
+                    <BitsShortName>TOMRP</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for position in the ground station.</BitsName>
+                    <BitsUnit scale="0.00000000093132257461547851562">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="077">
+        <DataItemName>Time of ASTERIX Report Transmission</DataItemName>
+        <DataItemDefinition>
+            Time of the transmission of the ASTERIX category 021 report in the
+            form of elapsed time since last midnight, expressed as UTC.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="unsigned">
+                    <BitsShortName>077</BitsShortName>
+                    <BitsName>Time of ASTERIX Report Transmission</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="080">
+        <DataItemName>Target Address</DataItemName>
+        <DataItemDefinition>
+            Target address (emitter identifier) assigned uniquely to each target.
+        </DataItemDefinition>
+        <DataItemFormat desc="3-octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>080</BitsShortName>
+                    <BitsName>Target Address</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="090">
+        <DataItemName>Quality Indicators</DataItemName>
+        <DataItemDefinition>
+            ADS-B quality indicators transmitted by a/c according to MOPS version.
+        </DataItemDefinition>
+        <DataItemFormat desc="Variable data item.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>NUCR_NACV</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for velocity NUCr or the Navigation Accuracy Category for Velocity NACv</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NUCP_NIC</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for Position NUCp or Navigation Integrity Category NIC.</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>NICBARO</BitsShortName>
+                        <BitsName>Navigation Integrity Category for Barometric Altitude</BitsName>
+                    </Bits>
+                    <Bits from="7" to="6">
+                        <BitsShortName>SIL</BitsShortName>
+                        <BitsName>Surveillance (version 1) or Source (version 2) Integrity Level</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NACP</BitsShortName>
+                        <BitsName>Navigation Accuracy Category for Position</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bit(s) set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SILS</BitsShortName>
+                        <BitsName>SIL-Supplement</BitsName>
+                        <BitsValue val="0">measured per flight-hour</BitsValue>
+                        <BitsValue val="1">measured per sample</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>SDA</BitsShortName>
+                        <BitsName>Horizontal Position System Design Assurance Level (as defined in version 2)</BitsName>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>GVA</BitsShortName>
+                        <BitsName>Geometric Altitude Accuracy</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>PIC</BitsShortName>
+                        <BitsName>Position Integrity Category</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bit(s) set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="110">
+        <DataItemName>Trajectory Intent</DataItemName>
+        <DataItemDefinition>
+            Reports indicating the 4D intended trajectory of the aircraft.
+        </DataItemDefinition>
+        <DataItemFormat desc="Compound data item.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>TIS</BitsShortName>
+                            <BitsName>Trajectory Intent Status</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TID</BitsShortName>
+                            <BitsName>Trajectory Intent Data</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>NAV</BitsShortName>
+                            <BitsValue val="0">Trajectory Intent Data is available for this aircraft</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not available for this aircraft</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>NVB</BitsShortName>
+                            <BitsValue val="0">Trajectory Intent Data is valid</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not valid</BitsValue>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bit(s) set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+                            <BitsValue val="0">End of Data Item</BitsValue>
+                            <BitsValue val="1">Extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+
+                <Repetitive>
+                    <Fixed length="15">
+                        <Bits bit="120">
+                            <BitsShortName>TCA</BitsShortName>
+                            <BitsValue val="0">TCP number available</BitsValue>
+                            <BitsValue val="1">TCP number not available</BitsValue>
+                        </Bits>
+                        <Bits bit="119">
+                            <BitsShortName>NC</BitsShortName>
+                            <BitsValue val="0">TCP compliance</BitsValue>
+                            <BitsValue val="1">TCP non-compliance</BitsValue>
+                        </Bits>
+                        <Bits from="118" to="113">
+                            <BitsShortName>TCPNumber</BitsShortName>
+                        </Bits>
+                        <Bits from="112" to="97" encode="signed">
+                            <BitsShortName>Altitude</BitsShortName>
+                            <BitsName>Altitude in two's complement form</BitsName>
+                            <BitsUnit scale="10.0" min="-1500" max="150000">ft</BitsUnit>
+                        </Bits>
+                        <Bits from="96" to="73" encode="signed">
+                            <BitsShortName>Latitude</BitsShortName>
+                            <BitsName>In WGS.84 in two's complement.</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="72" to="49" encode="signed">
+                            <BitsShortName>Longitude</BitsShortName>
+                            <BitsName>In WGS.84 in two's complement.</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-180" max="180">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="48" to="45">
+                            <BitsShortName>PT</BitsShortName>
+                            <BitsName>Point Type</BitsName>
+                            <BitsValue val="0">Unknown</BitsValue>
+                            <BitsValue val="1">Fly by waypoint (LT)</BitsValue>
+                            <BitsValue val="2">Fly over waypoint (LT)</BitsValue>
+                            <BitsValue val="3">Hold pattern (LT)</BitsValue>
+                            <BitsValue val="4">Procedure hold (LT)</BitsValue>
+                            <BitsValue val="5">Procedure turn (LT)</BitsValue>
+                            <BitsValue val="6">RF leg (LT)</BitsValue>
+                            <BitsValue val="7">Top of climb (VT)</BitsValue>
+                            <BitsValue val="8">Top of descent (VT)</BitsValue>
+                            <BitsValue val="9">Start of level (VT)</BitsValue>
+                            <BitsValue val="10">Cross-over altitude (VT)</BitsValue>
+                            <BitsValue val="11">Transition altitude (VT)</BitsValue>
+                        </Bits>
+                        <Bits from="44" to="43">
+                            <BitsShortName>TD</BitsShortName>
+                            <BitsValue val="0">N/A</BitsValue>
+                            <BitsValue val="1">Turn right</BitsValue>
+                            <BitsValue val="2">Turn left</BitsValue>
+                            <BitsValue val="3">No turn</BitsValue>
+                        </Bits>
+                        <Bits bit="42">
+                            <BitsShortName>TRA</BitsShortName>
+                            <BitsValue val="0">TTR not available</BitsValue>
+                            <BitsValue val="1">TTR available</BitsValue>
+                        </Bits>
+                        <Bits bit="41">
+                            <BitsShortName>TOA</BitsShortName>
+                            <BitsValue val="0">TOV available</BitsValue>
+                            <BitsValue val="1">TOV not available</BitsValue>
+                        </Bits>
+                        <Bits from="40" to="17" encode="unsigned">
+                            <BitsShortName>TOV</BitsShortName>
+                            <BitsName>Time Over Point</BitsName>
+                            <BitsUnit scale="1.0">s</BitsUnit>
+                        </Bits>
+                        <Bits from="16" to="1" encode="unsigned">
+                            <BitsShortName>TTR</BitsShortName>
+                            <BitsName>TCP Turn radius</BitsName>
+                            <BitsUnit scale="0.01" min="0" max="655.35">Nm</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                </Repetitive>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="130">
+        <DataItemName>Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>
+            Position in WGS-84 Co-ordinates.
+        </DataItemDefinition>
+        <DataItemFormat desc="6-octet fixed length data item.">
+            <Fixed length="6">
+                <Bits from="48" to="25" encode="signed">
+                    <BitsShortName>LAT</BitsShortName>
+                    <BitsName>Latitude</BitsName>
+                    <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+                </Bits>
+                <Bits from="24" to="1" encode="signed">
+                    <BitsShortName>LON</BitsShortName>
+                    <BitsName>Longitude</BitsName>
+                    <BitsUnit scale="0.000021457672119140625" min="-180" max="180">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="131">
+        <DataItemName>High-Resolution Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>
+            Position in WGS-84 Co-ordinates in high resolution.
+        </DataItemDefinition>
+        <DataItemFormat desc="8-octet fixed length data item.">
+            <Fixed length="8">
+                <Bits from="64" to="33" encode="signed">
+                    <BitsShortName>LAT</BitsShortName>
+                    <BitsName>Latitude</BitsName>
+                    <BitsUnit scale="0.0000001676380634307861328125" min="-90" max="90">deg</BitsUnit>
+                </Bits>
+                <Bits from="32" to="1" encode="signed">
+                    <BitsShortName>LON</BitsShortName>
+                    <BitsName>Longitude</BitsName>
+                    <BitsUnit scale="0.0000001676380634307861328125" min="-180" max="180">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="132">
+        <DataItemName>Message Amplitude</DataItemName>
+        <DataItemDefinition>
+            Amplitude, in dBm, of ADS-B messages received by the ground station,
+            coded in two&apos;s complement.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1" encode="signed">
+                    <BitsShortName>132</BitsShortName>
+                    <BitsName>Message Amplitude</BitsName>
+                    <BitsUnit scale="1.0">dBm</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="140">
+        <DataItemName>Geometric Height</DataItemName>
+        <DataItemDefinition>
+            Minimum height from a plane tangent to the earth&apos;s ellipsoid, defined
+            by WGS-84, in two&apos;s complement form.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>140</BitsShortName>
+                    <BitsName>Geometric Height</BitsName>
+                    <BitsUnit scale="6.25" min="-1500" max="150000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="145">
+        <DataItemName>Flight Level</DataItemName>
+        <DataItemDefinition>
+            Flight Level from barometric measurements,not QNH corrected, in two&apos;s
+            complement form.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>145</BitsShortName>
+                    <BitsName>Flight Level</BitsName>
+                    <BitsUnit scale="0.25" min="-15" max="1500">FL</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="146">
+        <DataItemName>Selected Altitude</DataItemName>
+        <DataItemDefinition>
+            The Selected Altitude as provided by the avionics and corresponding
+            either to the MCP/FCU Selected Altitude (the ATC cleared altitude
+            entered by the flight crew into the avionics) or to the FMS Selected Altitude.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>SAS</BitsShortName>
+                    <BitsName>Source Availability</BitsName>
+                    <BitsValue val="0">No source information provided</BitsValue>
+                    <BitsValue val="1">Source Information provided</BitsValue>
+                </Bits>
+                <Bits from="15" to="14">
+                    <BitsShortName>S</BitsShortName>
+                    <BitsName>Source</BitsName>
+                    <BitsValue val="0">Unknown</BitsValue>
+                    <BitsValue val="1">Aircraft Altitude (Holding Altitude)</BitsValue>
+                    <BitsValue val="2">MCP/FCU Selected Altitude</BitsValue>
+                    <BitsValue val="3">FMS Selected Altitude</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+                    <BitsShortName>ALT</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25.0" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="148">
+        <DataItemName>Final State Selected Altitude</DataItemName>
+        <DataItemDefinition>
+            The vertical intent value that corresponds with the ATC cleared altitude,
+            as derived from the Altitude Control Panel (MCP/FCU).
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>MV</BitsShortName>
+                    <BitsName>Manage Vertical Mode</BitsName>
+                    <BitsValue val="0">Not active or unknown</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="15">
+                    <BitsShortName>AH</BitsShortName>
+                    <BitsName>Altitude Hold Mode</BitsName>
+                    <BitsValue val="0">Not active or unknown</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="14">
+                    <BitsShortName>AM</BitsShortName>
+                    <BitsName>Approach Mode</BitsName>
+                    <BitsValue val="0">Not active or unknown</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+                    <BitsShortName>ALT</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25.0" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="150">
+        <DataItemName>Air Speed</DataItemName>
+        <DataItemDefinition>
+            Calculated Air Speed (Element of Air Vector).
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>IM</BitsShortName>
+                    <BitsValue val="0">Air Speed = IAS, LSB (Bit-1) = 2 -14 NM/s</BitsValue>
+                    <BitsValue val="1">Air Speed = Mach, LSB (Bit-1) = 0.001</BitsValue>
+                </Bits>
+                <Bits from="15" to="1">
+                    <BitsShortName>AS</BitsShortName>
+                    <BitsName>Air Speed (IAS or Mach)</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="151">
+        <DataItemName>True Airspeed</DataItemName>
+        <DataItemDefinition>
+            True Air Speed.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="unsigned">
+                    <BitsShortName>TAS</BitsShortName>
+                    <BitsName>True Air Speed</BitsName>
+                    <BitsUnit scale="1.0">kt</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="152">
+        <DataItemName>Magnetic Heading</DataItemName>
+        <DataItemDefinition>
+            Magnetic Heading (Element of Air Vector).
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="unsigned">
+                    <BitsShortName>152</BitsShortName>
+                    <BitsName>Magnetic Heading</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="155">
+        <DataItemName>Barometric Vertical Rate</DataItemName>
+        <DataItemDefinition>
+            Barometric Vertical Rate, in two&apos;s complement form.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+                    <BitsShortName>BVR</BitsShortName>
+                    <BitsName>Barometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/min</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="157">
+        <DataItemName>Geometric Vertical Rate</DataItemName>
+        <DataItemDefinition>
+            Geometric Vertical Rate, in two&apos;s complement form, with reference to WGS-84.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+                    <BitsShortName>GVR</BitsShortName>
+                    <BitsName>Geometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/min</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="160">
+        <DataItemName>Airborne Ground Vector</DataItemName>
+        <DataItemDefinition>
+            Ground Speed and Track Angle elements of Airborne Ground Vector.
+        </DataItemDefinition>
+        <DataItemFormat desc="4-octet fixed length data item.">
+            <Fixed length="4">
+                <Bits bit="32">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="31" to="17" encode="unsigned">
+                    <BitsShortName>GS</BitsShortName>
+                    <BitsName>Ground Speed referenced to WGS-84</BitsName>
+                    <BitsUnit scale="0.00006103515625" min="0" max="2">NM/s</BitsUnit>
+                </Bits>
+                <Bits from="16" to="1" encode="unsigned">
+                    <BitsShortName>TA</BitsShortName>
+                    <BitsName>Track Angle clockwise reference to True North</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="161">
+        <DataItemName>Track Number</DataItemName>
+        <DataItemDefinition>
+            An integer value representing a unique reference to a track record
+            within a particular track file.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bit(s) set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1">
+                    <BitsShortName>TRNUM</BitsShortName>
+                    <BitsName>Track number</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="165">
+        <DataItemName>Track Angle Rate</DataItemName>
+        <DataItemDefinition>
+            Rate of Turn, in two&apos;s complement form.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="11">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bit(s) set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="10" to="1" encode="signed">
+                    <BitsShortName>TAR</BitsShortName>
+                    <BitsName>Track Angle Rate</BitsName>
+                    <BitsUnit scale="0.03125" min="-16" max="16">deg/s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="170">
+        <DataItemName>Target Identification</DataItemName>
+        <DataItemDefinition>
+            Target (aircraft or vehicle) identification in 8 characters, as reported
+            by the target.
+        </DataItemDefinition>
+        <DataItemFormat desc="6-octet fixed length data item.">
+            <Fixed length="6">
+                <Bits from="48" to="1" encode="6bitschar">
+                    <BitsShortName>170</BitsShortName>
+                    <BitsName>Target Identification</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="200">
+        <DataItemName>Target Status</DataItemName>
+        <DataItemDefinition>
+            Status of the target
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>ICF</BitsShortName>
+                    <BitsName>Intent Change Flag (see Note)</BitsName>
+                    <BitsValue val="0">No intent change active</BitsValue>
+                    <BitsValue val="1">Intent change flag raised</BitsValue>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>LNAV</BitsShortName>
+                    <BitsName>LNAV Mode</BitsName>
+                    <BitsValue val="0">LNAV Mode engaged</BitsValue>
+                    <BitsValue val="1">LNAV Mode not engaged</BitsValue>
+                </Bits>
+                <Bits bit="6">
+                    <BitsShortName>ME</BitsShortName>
+                    <BitsName>Military emergency</BitsName>
+                    <BitsValue val="0">No military emergency</BitsValue>
+                    <BitsValue val="1">Military emergency</BitsValue>
+                </Bits>
+                <Bits from="5" to="3">
+                    <BitsShortName>PS</BitsShortName>
+                    <BitsName>Priority Status</BitsName>
+                    <BitsValue val="0">No emergency / not reported</BitsValue>
+                    <BitsValue val="1">General emergency</BitsValue>
+                    <BitsValue val="2">Lifeguard / medical emergency</BitsValue>
+                    <BitsValue val="3">Minimum fuel</BitsValue>
+                    <BitsValue val="4">No communications</BitsValue>
+                    <BitsValue val="5">Unlawful interference</BitsValue>
+                    <BitsValue val="6">Downed Aircraft</BitsValue>
+                </Bits>
+                <Bits from="2" to="1">
+                    <BitsShortName>SS</BitsShortName>
+                    <BitsName>Surveillance Status</BitsName>
+                    <BitsValue val="0">No condition reported</BitsValue>
+                    <BitsValue val="1">Permanent Alert (Emergency condition)</BitsValue>
+                    <BitsValue val="2">Temporary Alert (change in Mode 3/A Code other than emergency)</BitsValue>
+                    <BitsValue val="3">SPI set</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="210">
+        <DataItemName>MOPS Version</DataItemName>
+        <DataItemDefinition>
+            Identification of the MOPS version used by a/c to supply ADS-B information.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bit(s) set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>VNS</BitsShortName>
+                    <BitsName>Version Not Supported</BitsName>
+                    <BitsValue val="0">The MOPS Version is supported by the GS</BitsValue>
+                    <BitsValue val="1">The MOPS Version is not supported by the GS</BitsValue>
+                </Bits>
+                <Bits from="6" to="4">
+                    <BitsShortName>VN</BitsShortName>
+                    <BitsName>Version Number</BitsName>
+                    <BitsValue val="0">ED102/DO-260 [Ref. 8]</BitsValue>
+                    <BitsValue val="1">DO-260A [Ref. 9</BitsValue>
+                    <BitsValue val="2">ED102A/DO-260B [Ref. 11]</BitsValue>
+                </Bits>
+                <Bits from="3" to="1">
+                    <BitsShortName>LTT</BitsShortName>
+                    <BitsName>Link Technology Type</BitsName>
+                    <BitsValue val="0">Other</BitsValue>
+                    <BitsValue val="1">UAT</BitsValue>
+                    <BitsValue val="2">1090 ES</BitsValue>
+                    <BitsValue val="3">VDL 4</BitsValue>
+                    <BitsValue val="4">Not assigned</BitsValue>
+                    <BitsValue val="5">Not assigned</BitsValue>
+                    <BitsValue val="6">Not assigned</BitsValue>
+                    <BitsValue val="7">Not assigned</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="220">
+        <DataItemName>Met Information</DataItemName>
+        <DataItemDefinition>
+            Meteorological information.
+        </DataItemDefinition>
+        <DataItemFormat desc="Compound data item.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>WS</BitsShortName>
+                            <BitsName>Wind Speed</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>WD</BitsShortName>
+                            <BitsName>Wind Direction</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TMP</BitsShortName>
+                            <BitsName>Temperature</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TRB</BitsShortName>
+                            <BitsName>Turbulence</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+
+                <Fixed length="2">
+                    <Bits from="16" to="1" encode="unsigned">
+                        <BitsShortName>WS</BitsShortName>
+                        <BitsName>Wind Speed</BitsName>
+                        <BitsUnit scale="1.0" min="0" max="300">kt</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="2">
+                    <Bits from="16" to="1" encode="unsigned">
+                        <BitsShortName>WD</BitsShortName>
+                        <BitsName>Wind Direction</BitsName>
+                        <BitsUnit scale="1.0" min="1" max="360">deg</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="2">
+                    <Bits from="16" to="1" encode="signed">
+                        <BitsShortName>TMP</BitsShortName>
+                        <BitsName>Temperature</BitsName>
+                        <BitsUnit scale="0.25" min="-100" max="100">degC</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TRB</BitsShortName>
+                        <BitsName>Turbulence</BitsName>
+                        <BitsUnit min="0" max="15"></BitsUnit>
+                    </Bits>
+                </Fixed>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="230">
+        <DataItemName>Roll Angle</DataItemName>
+        <DataItemDefinition>
+            The roll angle, in two&apos;s complement form, of an aircraft executing a turn.
+        </DataItemDefinition>
+        <DataItemFormat desc="2-octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>230</BitsShortName>
+                    <BitsName>Roll Angle</BitsName>
+                    <BitsUnit scale="0.01" min="-180" max="180">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="250">
+        <DataItemName>Mode S MB Data</DataItemName>
+        <DataItemDefinition>
+            Mode S Comm B data as extracted from the aircraft transponder.
+        </DataItemDefinition>
+        <DataItemFormat desc="Repetitive data item.">
+            <Repetitive>
+                <BDS/>
+            </Repetitive>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="260">
+        <DataItemName>ACAS Resolution Advisory Report</DataItemName>
+        <DataItemDefinition>
+            Currently active Resolution Advisory (RA), if any, generated by the ACAS
+            associated with the transponder transmitting the RA message and threat
+            identity data.
+        </DataItemDefinition>
+        <DataItemFormat desc="7-octet fixed length data item.">
+            <Fixed length="7">
+                <Bits from="56" to="52">
+                    <BitsShortName>TYP</BitsShortName>
+                    <BitsName>Message Type (= 28 for 1090 ES, version 2)</BitsName>
+                </Bits>
+                <Bits from="51" to="49">
+                    <BitsShortName>STYP</BitsShortName>
+                    <BitsName>Message Sub-type (= 2 for 1090 ES, version 2)</BitsName>
+                </Bits>
+                <Bits from="48" to="35">
+                    <BitsShortName>ARA</BitsShortName>
+                    <BitsName>Active Resolution Advisories</BitsName>
+                </Bits>
+                <Bits from="34" to="31">
+                    <BitsShortName>RAC</BitsShortName>
+                    <BitsName>RAC (RA Complement) Record</BitsName>
+                </Bits>
+                <Bits bit="30">
+                    <BitsShortName>RAT</BitsShortName>
+                    <BitsName>RA Terminated</BitsName>
+                </Bits>
+                <Bits bit="29">
+                    <BitsShortName>MTE</BitsShortName>
+                    <BitsName>Multiple Threat Encounter</BitsName>
+                </Bits>
+                <Bits from="28" to="27">
+                    <BitsShortName>TTI</BitsShortName>
+                    <BitsName>Threat Type Indicator</BitsName>
+                </Bits>
+                <Bits from="26" to="1">
+                    <BitsShortName>TID</BitsShortName>
+                    <BitsName>Threat Identity Data</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="271">
+        <DataItemName>Surface Capabilities and Characteristics</DataItemName>
+        <DataItemDefinition>
+            Operational capabilities of the aircraft while on the ground.
+        </DataItemDefinition>
+        <DataItemFormat desc="Variable data item.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bit(s) set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>POA</BitsShortName>
+                        <BitsName>Position Offset Applied</BitsName>
+                        <BitsValue val="0">Position transmitted is not ADS-B position reference point</BitsValue>
+                        <BitsValue val="1">Position transmitted is the ADS-B position reference point</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>CDTI_S</BitsShortName>
+                        <BitsName>Cockpit Display of Traffic Information Surface</BitsName>
+                        <BitsValue val="0">CDTI not operational</BitsValue>
+                        <BitsValue val="1">CDTI operational</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>B2low</BitsShortName>
+                        <BitsName>Class B2 transmit power less than 70 Watts</BitsName>
+                        <BitsValue val="0">&gt;= 70 Watts</BitsValue>
+                        <BitsValue val="1">&lt; 70 Watts</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RAS</BitsShortName>
+                        <BitsName>Receiving ATC Services</BitsName>
+                        <BitsValue val="0">Aircraft not receiving ATC-services</BitsValue>
+                        <BitsValue val="1">Aircraft receiving ATC services</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>IDENT</BitsShortName>
+                        <BitsName>Setting of 'IDENT'-switch</BitsName>
+                        <BitsValue val="0">IDENT switch not active</BitsValue>
+                        <BitsValue val="1">IDENT switch active</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>LW</BitsShortName>
+                        <BitsName>Length and width of the aircraft</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bit(s) set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="295">
+        <DataItemName>Data Ages</DataItemName>
+        <DataItemDefinition>
+            Ages of the data provided.
+        </DataItemDefinition>
+        <DataItemFormat desc="Compound data item.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>AOS</BitsShortName>
+                            <BitsName>Aircraft Operational Status Age</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TRD</BitsShortName>
+                            <BitsName>Target Report Descriptor Age</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>M3A</BitsShortName>
+                            <BitsName>Mode 3/A Age</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>QI</BitsShortName>
+                            <BitsName>Quality Indicators Age</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TI1</BitsShortName>
+                            <BitsName>Trajectory Intent Age</BitsName>
+                            <BitsPresence>5</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MAM</BitsShortName>
+                            <BitsName>Message Amplitude Age</BitsName>
+                            <BitsPresence>6</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>GH</BitsShortName>
+                            <BitsName>Geometric Height Age</BitsName>
+                            <BitsPresence>7</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>FL</BitsShortName>
+                            <BitsName>Flight Level Age</BitsName>
+                            <BitsPresence>8</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>ISA</BitsShortName>
+                            <BitsName>Intermediate State Selected Altitude Age</BitsName>
+                            <BitsPresence>9</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>FSA</BitsShortName>
+                            <BitsName>Final State Selected Altitude Age</BitsName>
+                            <BitsPresence>10</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>AS</BitsShortName>
+                            <BitsName>Air Speed Age</BitsName>
+                            <BitsPresence>11</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TAS</BitsShortName>
+                            <BitsName>True Air Speed Age</BitsName>
+                            <BitsPresence>12</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MH</BitsShortName>
+                            <BitsName>Magnetic Heading Age</BitsName>
+                            <BitsPresence>13</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>BVR</BitsShortName>
+                            <BitsName>Barometric Vertical Rate Age</BitsName>
+                            <BitsPresence>14</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>GVR</BitsShortName>
+                            <BitsName>Geometric Vertical Rate Age</BitsName>
+                            <BitsPresence>15</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>GV</BitsShortName>
+                            <BitsName>Ground Vector Age</BitsName>
+                            <BitsPresence>16</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TAR</BitsShortName>
+                            <BitsName>Track Angle Rate Age</BitsName>
+                            <BitsPresence>17</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TI2</BitsShortName>
+                            <BitsName>Target Identification Age</BitsName>
+                            <BitsPresence>18</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TS</BitsShortName>
+                            <BitsName>Target Status Age</BitsName>
+                            <BitsPresence>19</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MET</BitsShortName>
+                            <BitsName>Met Information Age</BitsName>
+                            <BitsPresence>20</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>ROA</BitsShortName>
+                            <BitsName>Roll Angle Age</BitsName>
+                            <BitsPresence>21</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>ARA</BitsShortName>
+                            <BitsName>ACAS Resolution Advisory Age</BitsName>
+                            <BitsPresence>22</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>SCC</BitsShortName>
+                            <BitsName>Surface Capabilities and Characteristics Age</BitsName>
+                            <BitsPresence>23</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>AOS</BitsShortName>
+                        <BitsName>Aircraft Operational Status Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TRD</BitsShortName>
+                        <BitsName>Target Report Descriptor Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>M3A</BitsShortName>
+                        <BitsName>Mode 3/A Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>QI</BitsShortName>
+                        <BitsName>Quality Indicators Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TI1</BitsShortName>
+                        <BitsName>Trajectory Intent Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>MAM</BitsShortName>
+                        <BitsName>Message Amplitude Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>GH</BitsShortName>
+                        <BitsName>Geometric Height Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>FL</BitsShortName>
+                        <BitsName>Flight Level Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>ISA</BitsShortName>
+                        <BitsName>Intermediate State Selected Altitude Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>FSA</BitsShortName>
+                        <BitsName>Final State Selected Altitude Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>AS</BitsShortName>
+                        <BitsName>Air Speed Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TAS</BitsShortName>
+                        <BitsName>True Air Speed Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>MH</BitsShortName>
+                        <BitsName>Magnetic Heading Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>BVR</BitsShortName>
+                        <BitsName>Barometric Vertical Rate Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>GVR</BitsShortName>
+                        <BitsName>Geometric Vertical Rate Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>GV</BitsShortName>
+                        <BitsName>Ground Vector Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TAR</BitsShortName>
+                        <BitsName>Track Angle Rate Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TI2</BitsShortName>
+                        <BitsName>Target Identification Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>TS</BitsShortName>
+                        <BitsName>Target Status Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>MET</BitsShortName>
+                        <BitsName>Met Information Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>ROA</BitsShortName>
+                        <BitsName>Roll Angle Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>ARA</BitsShortName>
+                        <BitsName>ACAS Resolution Advisory Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+
+                <Fixed length="1">
+                    <Bits from="8" to="1" encode="unsigned">
+                        <BitsShortName>SCC</BitsShortName>
+                        <BitsName>Surface Capabilities and Characteristics Age</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="400">
+        <DataItemName>Receiver ID</DataItemName>
+        <DataItemDefinition>
+            Designator of Ground Station in Distributed System.
+        </DataItemDefinition>
+        <DataItemFormat desc="1-octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>400</BitsShortName>
+                    <BitsName>Receiver ID</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="RE">
+        <DataItemName>Reserved Expansion Field</DataItemName>
+        <DataItemDefinition>
+            Expansion
+        </DataItemDefinition>
+        <DataItemFormat desc="Explicit data item.">
+            <Explicit>
+            <DataItemFormat desc="Compound data item.">
+                <Compound>
+                    <Variable>
+                        <Fixed length="1">
+                            <Bits bit="8">
+                                <BitsShortName>BPS</BitsShortName>
+                                <BitsName>Barometric Pressure Setting</BitsName>
+                                <BitsPresence>1</BitsPresence>
+                            </Bits>
+                            <Bits bit="7">
+                                <BitsShortName>SelH</BitsShortName>
+                                <BitsName>Selected Heading</BitsName>
+                                <BitsPresence>2</BitsPresence>
+                            </Bits>
+                            <Bits bit="6">
+                                <BitsShortName>NAV</BitsShortName>
+                                <BitsName>Navigation Mode</BitsName>
+                                <BitsPresence>3</BitsPresence>
+                            </Bits>
+                            <Bits bit="5">
+                                <BitsShortName>GAO</BitsShortName>
+                                <BitsName>GPS Antenna Offset</BitsName>
+                                <BitsPresence>4</BitsPresence>
+                            </Bits>
+                            <Bits bit="4">
+                                <BitsShortName>SGV</BitsShortName>
+                                <BitsName>Surface Ground Vector</BitsName>
+                                <BitsPresence>5</BitsPresence>
+                            </Bits>
+                            <Bits bit="3">
+                                <BitsShortName>STA</BitsShortName>
+                                <BitsName>Aircraft Status</BitsName>
+                                <BitsPresence>6</BitsPresence>
+                            </Bits>
+                            <Bits bit="2">
+                                <BitsShortName>TNH</BitsShortName>
+                                <BitsName>True North Heading</BitsName>
+                                <BitsPresence>7</BitsPresence>
+                            </Bits>
+                            <Bits bit="1">
+                                <BitsShortName>MES</BitsShortName>
+                                <BitsName>Military Extended Squitter</BitsName>
+                                <BitsPresence>8</BitsPresence>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+
+                    <Fixed length="2">
+                        <Bits from="16" to="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bit(s) set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="12" to="1" encode="unsigned">
+                            <BitsShortName>BPS</BitsShortName>
+                            <BitsName>Barometric Pressure Setting</BitsName>
+                            <BitsUnit scale="0.1" min="0" max="409.5">hPa</BitsUnit>
+                        </Bits>
+                    </Fixed>
+
+                    <Fixed length="2">
+                        <Bits from="16" to="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bit(s) set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="12">
+                            <BitsShortName>HDR</BitsShortName>
+                            <BitsName>Horizontal Reference Direction</BitsName>
+                            <BitsValue val="0">True North</BitsValue>
+                            <BitsValue val="1">Magnetic North</BitsValue>
+                        </Bits>
+                        <Bits bit="11">
+                            <BitsShortName>Stat</BitsShortName>
+                            <BitsName>Selected Heading Status</BitsName>
+                            <BitsValue val="0">Data is either unavailable or invalid.</BitsValue>
+                            <BitsValue val="1">Data is available and valid.</BitsValue>
+                        </Bits>
+                        <Bits from="10" to="1" encode="unsigned">
+                            <BitsShortName>SelH</BitsShortName>
+                            <BitsName>Selected Heading</BitsName>
+                            <BitsUnit scale="0.703125">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>AP</BitsShortName>
+                            <BitsName>Autopilot</BitsName>
+                            <BitsValue val="0">Autopilot not engaged</BitsValue>
+                            <BitsValue val="1">Autopilot engaged</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>VN</BitsShortName>
+                            <BitsName>Vertical Navigation</BitsName>
+                            <BitsValue val="0">Vertical Navigation not active</BitsValue>
+                            <BitsValue val="1">Vertical Navigation active</BitsValue>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>AH</BitsShortName>
+                            <BitsName>Altitude Hold</BitsName>
+                            <BitsValue val="0">Altitude Hold not engaged</BitsValue>
+                            <BitsValue val="1">Altitude Hold engaged</BitsValue>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>AM</BitsShortName>
+                            <BitsName>Approach Mode</BitsName>
+                            <BitsValue val="0">Approach Mode not active</BitsValue>
+                            <BitsValue val="1">Approach Mode active</BitsValue>
+                        </Bits>
+                        <Bits from="4" to="1">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bit(s) set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                    </Fixed>
+
+                    <Fixed length="1">
+                        <Bits from="8" to="1">
+                            <BitsShortName>GAO</BitsShortName>
+                            <BitsName>GPS Antenna Offset</BitsName>
+                        </Bits>
+                    </Fixed>
+
+                    <Variable>
+                        <Fixed length="2">
+                            <Bits bit="16">
+                                <BitsShortName>STP</BitsShortName>
+                                <BitsValue val="0">Aircraft has not stopped</BitsValue>
+                                <BitsValue val="1">Aircraft has stopped</BitsValue>
+                            </Bits>
+                            <Bits bit="15">
+                                <BitsShortName>HTS</BitsShortName>
+                                <BitsValue val="0">Heading/Ground Track data is not valid</BitsValue>
+                                <BitsValue val="1">Heading/Ground Track data is valid</BitsValue>
+                            </Bits>
+                            <Bits bit="14">
+                                <BitsShortName>HTT</BitsShortName>
+                                <BitsValue val="0">Heading data provided</BitsValue>
+                                <BitsValue val="1">Ground Track provided</BitsValue>
+                            </Bits>
+                            <Bits bit="13">
+                                <BitsShortName>HRD</BitsShortName>
+                                <BitsValue val="0">True North</BitsValue>
+                                <BitsValue val="1">Magnetic North</BitsValue>
+                            </Bits>
+                            <Bits from="12" to="2" encode="unsigned">
+                                <BitsShortName>GSS</BitsShortName>
+                                <BitsName>Ground speed</BitsName>
+                                <BitsUnit scale="0.125">kts</BitsUnit>
+                            </Bits>
+                            <Bits bit="1" fx="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension Indicator</BitsName>
+                                <BitsValue val="0">End of Data Item</BitsValue>
+                                <BitsValue val="1">Extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                        <Fixed length="1">
+                            <Bits from="8" to="2" encode="unsigned">
+                                <BitsShortName>HGT</BitsShortName>
+                                <BitsName>Heading/Ground Track information</BitsName>
+                                <BitsUnit scale="2.8125">deg</BitsUnit>
+                            </Bits>
+                            <Bits bit="1" fx="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension Indicator</BitsName>
+                                <BitsValue val="0">End of Data Item</BitsValue>
+                                <BitsValue val="1">Extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+
+                    <Variable>
+                        <Fixed length="1">
+                            <Bits bit="8">
+                                <BitsShortName>ES</BitsShortName>
+                                <BitsValue val="0">Target is not 1090 ES IN capable</BitsValue>
+                                <BitsValue val="1">Target is 1090 ES IN capable</BitsValue>
+                            </Bits>
+                            <Bits bit="7">
+                                <BitsShortName>UAT</BitsShortName>
+                                <BitsValue val="0">Target is not UAT IN capable</BitsValue>
+                                <BitsValue val="1">Target is UAT IN capable</BitsValue>
+                            </Bits>
+                            <Bits from="6" to="2">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits bit="1" fx="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension Indicator</BitsName>
+                                <BitsValue val="0">End of Data Item</BitsValue>
+                                <BitsValue val="1">Extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+
+                    <Fixed length="2">
+                        <Bits from="16" to="1" encode="unsigned">
+                            <BitsShortName>TNH</BitsShortName>
+                            <BitsName>True North Heading</BitsName>
+                            <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+
+                    <Compound>
+                        <Variable>
+                            <Fixed length="1">
+                                <Bits bit="8">
+                                    <BitsShortName>SUM</BitsShortName>
+                                    <BitsName>Mode 5 Summary</BitsName>
+                                    <BitsPresence>1</BitsPresence>
+                                </Bits>
+                                <Bits bit="7">
+                                    <BitsShortName>PNO</BitsShortName>
+                                    <BitsName>Mode 5 PIN /National Origin</BitsName>
+                                    <BitsPresence>2</BitsPresence>
+                                </Bits>
+                                <Bits bit="6">
+                                    <BitsShortName>EM1</BitsShortName>
+                                    <BitsName>Extended Mode 1 Code in Octal Representation</BitsName>
+                                    <BitsPresence>3</BitsPresence>
+                                </Bits>
+                                <Bits bit="5">
+                                    <BitsShortName>XP</BitsShortName>
+                                    <BitsName>X Pulse Presence</BitsName>
+                                    <BitsPresence>4</BitsPresence>
+                                </Bits>
+                                <Bits bit="4">
+                                    <BitsShortName>FOM</BitsShortName>
+                                    <BitsName>Figure of Merit</BitsName>
+                                    <BitsPresence>5</BitsPresence>
+                                </Bits>
+                                <Bits bit="3">
+                                    <BitsShortName>M2</BitsShortName>
+                                    <BitsName>Mode 2 Code in Octal Representation</BitsName>
+                                    <BitsPresence>6</BitsPresence>
+                                </Bits>
+                                <Bits bit="2">
+                                    <BitsShortName>spare</BitsShortName>
+                                    <BitsName>Spare bits set to 0</BitsName>
+                                </Bits>
+                                <Bits bit="1" fx="1">
+                                    <BitsShortName>FX</BitsShortName>
+                                    <BitsName>Extension indicator</BitsName>
+                                    <BitsValue val="0">no extension</BitsValue>
+                                    <BitsValue val="1">extension</BitsValue>
+                                </Bits>
+                            </Fixed>
+                        </Variable>
+
+                        <Fixed length="1">
+                            <Bits bit="8">
+                                <BitsShortName>M5</BitsShortName>
+                                <BitsValue val="0">No Mode 5 interrogation</BitsValue>
+                                <BitsValue val="1">Mode 5 interrogation</BitsValue>
+                            </Bits>
+                            <Bits bit="7">
+                                <BitsShortName>ID</BitsShortName>
+                                <BitsValue val="0">No authenticated Mode 5 ID reply/report</BitsValue>
+                                <BitsValue val="1">Authenticated Mode 5 ID reply/report</BitsValue>
+                            </Bits>
+                            <Bits bit="6">
+                                <BitsShortName>DA</BitsShortName>
+                                <BitsValue val="0">No authenticated Mode 5 Data reply or Report</BitsValue>
+                                <BitsValue val="1">Authenticated Mode 5 Data reply or Report (i.e any valid Mode 5 reply type other than ID)</BitsValue>
+                            </Bits>
+                            <Bits bit="5">
+                                <BitsShortName>M1</BitsShortName>
+                                <BitsValue val="0">Mode 1 code not present or not from Mode 5 reply/report</BitsValue>
+                                <BitsValue val="1">Mode 1 code from Mode 5 reply/report.</BitsValue>
+                            </Bits>
+                            <Bits bit="4">
+                                <BitsShortName>M2</BitsShortName>
+                                <BitsValue val="0">Mode 2 code not present or not from Mode 5 reply/report</BitsValue>
+                                <BitsValue val="1">Mode 2 code from Mode 5 reply/report.</BitsValue>
+                            </Bits>
+                            <Bits bit="3">
+                                <BitsShortName>M3</BitsShortName>
+                                <BitsValue val="0">Mode 3 code not present or not from Mode 5 reply/report</BitsValue>
+                                <BitsValue val="1">Mode 3 code from Mode 5 reply/report.</BitsValue>
+                            </Bits>
+                            <Bits bit="2">
+                                <BitsShortName>MC</BitsShortName>
+                                <BitsValue val="0">Flightlevel not present or not from Mode 5 reply/report</BitsValue>
+                                <BitsValue val="1">Flightlevel from Mode 5 reply/report</BitsValue>
+                            </Bits>
+                            <Bits bit="1">
+                                <BitsShortName>PO</BitsShortName>
+                                <BitsValue val="0">Position not from Mode 5 report (ADS-B report)</BitsValue>
+                                <BitsValue val="1">Position from Mode 5 report</BitsValue>
+                            </Bits>
+                        </Fixed>
+
+                        <Fixed length="4">
+                            <Bits from="32" to="31">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits from="30" to="17">
+                                <BitsShortName>PIN</BitsShortName>
+                                <BitsName>PIN Code</BitsName>
+                            </Bits>
+                            <Bits from="16" to="12">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits from="11" to="1">
+                                <BitsShortName>NO</BitsShortName>
+                                <BitsName>National Origin Code</BitsName>
+                            </Bits>
+                        </Fixed>
+
+                        <Fixed length="2">
+                            <Bits bit="16">
+                                <BitsShortName>V</BitsShortName>
+                                <BitsValue val="0">Code validated</BitsValue>
+                                <BitsValue val="1">Code not validated</BitsValue>
+                            </Bits>
+                            <Bits bit="15">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits bit="14">
+                                <BitsShortName>L</BitsShortName>
+                                <BitsValue val="0">Mode 1 code as derived from the report of the transponder</BitsValue>
+                                <BitsValue val="1">Smoothed Mode 1 code as provided by a local tracker</BitsValue>
+                            </Bits>
+                            <Bits bit="13">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits from="12" to="1" encode="octal">
+                                <BitsShortName>EM1</BitsShortName>
+                                <BitsName>Extended Mode 1 Code in Octal Representation</BitsName>
+                            </Bits>
+                        </Fixed>
+
+                        <Fixed length="1">
+                            <Bits from="8" to="7">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits bit="6">
+                                <BitsShortName>XP</BitsShortName>
+                                <BitsName>X-pulse from Mode 5 PIN reply/report</BitsName>
+                                <BitsValue val="0">X-Pulse not present.</BitsValue>
+                                <BitsValue val="1">X-pulse present.</BitsValue>
+                            </Bits>
+                            <Bits bit="5">
+                                <BitsShortName>X5</BitsShortName>
+                                <BitsName>X-pulse from Mode 5 Data reply or Report.</BitsName>
+                                <BitsValue val="0">X-pulse set to zero or no authenticated Data reply or Report received.</BitsValue>
+                                <BitsValue val="1">X-pulse set to one (present).</BitsValue>
+                            </Bits>
+                            <Bits bit="4">
+                                <BitsShortName>XC</BitsShortName>
+                                <BitsName>X-pulse from Mode C reply</BitsName>
+                                <BitsValue val="0">X-pulse set to zero or no Mode C reply</BitsValue>
+                                <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                            </Bits>
+                            <Bits bit="3">
+                                <BitsShortName>X3</BitsShortName>
+                                <BitsName>X-pulse from Mode 3/A reply</BitsName>
+                                <BitsValue val="0">X-pulse set to zero or no Mode 3/A reply&amp;quot;</BitsValue>
+                                <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                            </Bits>
+                            <Bits bit="2">
+                                <BitsShortName>X2</BitsShortName>
+                                <BitsName>X-pulse from Mode 2 reply</BitsName>
+                                <BitsValue val="0">0 X-pulse set to zero or no Mode 2 reply</BitsValue>
+                                <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                            </Bits>
+                            <Bits bit="1">
+                                <BitsShortName>X1</BitsShortName>
+                                <BitsName>X-pulse from Mode 1 reply</BitsName>
+                                <BitsValue val="0">X-pulse set to zero or no Mode 1 reply</BitsValue>
+                                <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                            </Bits>
+                        </Fixed>
+
+                        <Fixed length="1">
+                            <Bits from="8" to="6">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits from="5" to="1">
+                                <BitsShortName>FOM</BitsShortName>
+                                <BitsName>Figure of Merit</BitsName>
+                            </Bits>
+                        </Fixed>
+
+                        <Fixed length="2">
+                            <Bits bit="16">
+                                <BitsShortName>V</BitsShortName>
+                                <BitsValue val="0">Code validated</BitsValue>
+                                <BitsValue val="1">Code not validated</BitsValue>
+                            </Bits>
+                            <Bits bit="15">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits bit="14">
+                                <BitsShortName>L</BitsShortName>
+                                <BitsValue val="0">Mode 1 code as derived from the report of the transponder</BitsValue>
+                                <BitsValue val="1">Smoothed Mode 1 code as provided by a local tracker</BitsValue>
+                            </Bits>
+                            <Bits bit="13">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit(s) set to 0</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                            <Bits from="12" to="1" encode="octal">
+                                <BitsShortName>ABCD</BitsShortName>
+                                <BitsName>Mode 2 Code in Octal Representation</BitsName>
+                            </Bits>
+                        </Fixed>
+                    </Compound>
+                </Compound>
+            </DataItemFormat>
+            </Explicit>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="SP">
+        <DataItemName>Special Purpose Field</DataItemName>
+        <DataItemDefinition>
+            Special Purpose Field
+        </DataItemDefinition>
+        <DataItemFormat desc="Explicit data item.">
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>LEN</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
+        </DataItemFormat>
+    </DataItem>
+
+    <UAP>
+        <UAPItem bit="0" frn="1">010</UAPItem>
+        <UAPItem bit="1" frn="2">040</UAPItem>
+        <UAPItem bit="2" frn="3">161</UAPItem>
+        <UAPItem bit="3" frn="4">015</UAPItem>
+        <UAPItem bit="4" frn="5">071</UAPItem>
+        <UAPItem bit="5" frn="6">130</UAPItem>
+        <UAPItem bit="6" frn="7">131</UAPItem>
+        <UAPItem bit="7" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="8" frn="8">072</UAPItem>
+        <UAPItem bit="9" frn="9">150</UAPItem>
+        <UAPItem bit="10" frn="10">151</UAPItem>
+        <UAPItem bit="11" frn="11">080</UAPItem>
+        <UAPItem bit="12" frn="12">073</UAPItem>
+        <UAPItem bit="13" frn="13">074</UAPItem>
+        <UAPItem bit="14" frn="14">075</UAPItem>
+        <UAPItem bit="15" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="16" frn="15">076</UAPItem>
+        <UAPItem bit="17" frn="16">140</UAPItem>
+        <UAPItem bit="18" frn="17">090</UAPItem>
+        <UAPItem bit="19" frn="18">210</UAPItem>
+        <UAPItem bit="20" frn="19">070</UAPItem>
+        <UAPItem bit="21" frn="20">230</UAPItem>
+        <UAPItem bit="22" frn="21">145</UAPItem>
+        <UAPItem bit="23" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="24" frn="22">152</UAPItem>
+        <UAPItem bit="25" frn="23">200</UAPItem>
+        <UAPItem bit="26" frn="24">155</UAPItem>
+        <UAPItem bit="27" frn="25">157</UAPItem>
+        <UAPItem bit="28" frn="26">160</UAPItem>
+        <UAPItem bit="29" frn="27">165</UAPItem>
+        <UAPItem bit="30" frn="28">077</UAPItem>
+        <UAPItem bit="31" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="32" frn="29">170</UAPItem>
+        <UAPItem bit="33" frn="30">020</UAPItem>
+        <UAPItem bit="34" frn="31">220</UAPItem>
+        <UAPItem bit="35" frn="32">146</UAPItem>
+        <UAPItem bit="36" frn="33">148</UAPItem>
+        <UAPItem bit="37" frn="34">110</UAPItem>
+        <UAPItem bit="38" frn="35">016</UAPItem>
+        <UAPItem bit="39" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="40" frn="36">008</UAPItem>
+        <UAPItem bit="41" frn="37">271</UAPItem>
+        <UAPItem bit="42" frn="38">132</UAPItem>
+        <UAPItem bit="43" frn="39">250</UAPItem>
+        <UAPItem bit="44" frn="40">260</UAPItem>
+        <UAPItem bit="45" frn="41">400</UAPItem>
+        <UAPItem bit="46" frn="42">295</UAPItem>
+        <UAPItem bit="47" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="48" frn="43">-</UAPItem>
+        <UAPItem bit="49" frn="44">-</UAPItem>
+        <UAPItem bit="50" frn="45">-</UAPItem>
+        <UAPItem bit="51" frn="46">-</UAPItem>
+        <UAPItem bit="52" frn="47">-</UAPItem>
+        <UAPItem bit="53" frn="48">RE</UAPItem>
+        <UAPItem bit="54" frn="49">SP</UAPItem>
+        <UAPItem bit="55" frn="FX" len="-">-</UAPItem>
+    </UAP>
+
+</Category>

--- a/asterix-specs-converter/asterix_cat021_2_4.xml
+++ b/asterix-specs-converter/asterix_cat021_2_4.xml
@@ -1,0 +1,2203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Category SYSTEM "asterix.dtd">
+
+<!--
+
+    Asterix Category 021 v2.4 definition
+
+    Author:   B.Bertrand
+    Created:  2012-12-17
+    Modified:  28.4.2014. (dsalantic) Special characters removed from BitsShortName, some BitsShortName renamed, tabs aligned
+    Modified:  23.2.2016. (ifsnop) Added RE dataitem from "ASTERIX Part 12 Category 021 Appendix A Coding rules for Reserved Expansion Field v1.1"
+    Modified:  21.1.2019. (Michael Thibeault) Version 2.4 created
+
+-->
+
+<Category id="021" name="Surveillance Data Exchange - Part 12 ADS-B Reports" ver="2.4">
+
+
+    <DataItem id="008" rule="optional">
+        <DataItemName>Aircraft Operational Status</DataItemName>
+        <DataItemDefinition>Identification of the operational services available in the aircraft while airborne.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>RA</BitsShortName>
+                    <BitsName>TCAS Resolution Advisory active</BitsName>
+                    <BitsValue val="0">TCAS II or ACAS RA not active</BitsValue>
+                    <BitsValue val="1">TCAS RA active</BitsValue>
+                </Bits>
+                <Bits from="7" to="6">
+                    <BitsShortName>TC</BitsShortName>
+                    <BitsName>Target Change Report Capability</BitsName>
+                    <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
+                    <BitsValue val="1">support for TC+0 reports only</BitsValue>
+                    <BitsValue val="2">support for multiple TC reports</BitsValue>
+                    <BitsValue val="3">reserved</BitsValue>
+                </Bits>
+                <Bits bit="5">
+                    <BitsShortName>TS</BitsShortName>
+                    <BitsName>Target State Report Capability</BitsName>
+                    <BitsValue val="0">no capability to support Target State Reports</BitsValue>
+                    <BitsValue val="1">capable of supporting target State Reports</BitsValue>
+                </Bits>
+                <Bits bit="4">
+                    <BitsShortName>ARV</BitsShortName>
+                    <BitsName>Air-Referenced Velocity Report Capability</BitsName>
+                    <BitsValue val="0">no capability to generate ARV-reports</BitsValue>
+                    <BitsValue val="1">capable of generate ARV-reports</BitsValue>
+                </Bits>
+                <Bits bit="3">
+                    <BitsShortName>CDTI_A</BitsShortName>
+                    <BitsName>Cockpit Display of Traffic Information airborne</BitsName>
+                    <BitsValue val="0">CDTI not operational</BitsValue>
+                    <BitsValue val="1">CDTI operational</BitsValue>
+                </Bits>
+                <Bits bit="2">
+                    <BitsShortName>not_TCAS</BitsShortName>
+                    <BitsName>TCAS System Status</BitsName>
+                    <BitsValue val="0">TCAS operational or unknown</BitsValue>
+                    <BitsValue val="1">TCAS not installed or not operational</BitsValue>
+                </Bits>
+                <Bits bit="1">
+                    <BitsShortName>SA</BitsShortName>
+                    <BitsName>Single Antenna</BitsName>
+                    <BitsValue val="0">Antenna Diversity</BitsValue>
+                    <BitsValue val="1">Single Antenna only</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="010" rule="mandatory">
+        <DataItemName>Data Source Identification</DataItemName>
+        <DataItemDefinition>Identification of the ADS-B station providing information.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="9">
+                    <BitsShortName>SAC</BitsShortName>
+                    <BitsName>System Area Code</BitsName>
+                </Bits>
+                <Bits from="8" to="1">
+                    <BitsShortName>SIC</BitsShortName>
+                    <BitsName>System Identification Code</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The up-to-date list of SACs is published on the EUROCONTROL ASTERIX Web Site (http://www.eurocontrol.int/services/system-area-code-list).</DataItemNote>
+    </DataItem>
+
+    <DataItem id="015" rule="optional">
+        <DataItemName>Service Identification</DataItemName>
+        <DataItemDefinition>Identification of the service provided to one or more users.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>id</BitsShortName>
+                    <BitsName>Service Identification</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1- The service identification is allocated by the system.
+2- The service identification is also available in item I023/015 [Ref. 3].
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="016" rule="optional">
+        <DataItemName>Service Management</DataItemName>
+        <DataItemDefinition>Identification of services offered by a ground station (identified by a SIC code).</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>RP</BitsShortName>
+                    <BitsName>Report Period</BitsName>
+                    <BitsUnit scale="0.5" min="0" max="127.5">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. This item contains the same information as item I023/101 in ASTERIX category 023 [Ref. 3]. Since not all service users receive category 023 data, this information has to be conveyed in category 021 as well. 2. If this item is due to be sent according to the encoding rule above, it shall be sent with the next target report</DataItemNote>
+    </DataItem>
+
+    <DataItem id="020" rule="optional">
+        <DataItemName>Emitter Category</DataItemName>
+        <DataItemDefinition>Characteristics of the originating ADS-B unit.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>ECAT</BitsShortName>
+                    <BitsName>Emitter Category</BitsName>
+                    <BitsValue val="0">No ADS-B Emitter Category Information</BitsValue>
+                    <BitsValue val="1">light aircraft &lt;= 15500 lbs</BitsValue>
+                    <BitsValue val="2">15500 lbs &lt; small aircraft &lt; 75000 lbs</BitsValue>
+                    <BitsValue val="3">75000 lbs &lt; medium a/c &lt; 300000 lbs</BitsValue>
+                    <BitsValue val="4">High Vortex Large</BitsValue>
+                    <BitsValue val="5">300000 lbs &lt;= heavy aircraft</BitsValue>
+                    <BitsValue val="6">highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise)</BitsValue>
+                    <BitsValue val="7">reserved</BitsValue>
+                    <BitsValue val="8">reserved</BitsValue>
+                    <BitsValue val="9">reserved</BitsValue>
+                    <BitsValue val="10">rotocraft</BitsValue>
+                    <BitsValue val="11">glider / sailplane</BitsValue>
+                    <BitsValue val="12">lighter-than-air</BitsValue>
+                    <BitsValue val="13">unmanned aerial vehicle</BitsValue>
+                    <BitsValue val="14">space / transatmospheric vehicle</BitsValue>
+                    <BitsValue val="15">ultralight / handglider / paraglider</BitsValue>
+                    <BitsValue val="16">parachutist / skydiver</BitsValue>
+                    <BitsValue val="17">reserved</BitsValue>
+                    <BitsValue val="18">reserved</BitsValue>
+                    <BitsValue val="19">reserved</BitsValue>
+                    <BitsValue val="20">surface emergency vehicle</BitsValue>
+                    <BitsValue val="21">surface service vehicle</BitsValue>
+                    <BitsValue val="22">fixed ground or tethered obstruction</BitsValue>
+                    <BitsValue val="23">cluster obstacle</BitsValue>
+                    <BitsValue val="24">line obstacle</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="040" rule="mandatory">
+        <DataItemName>Target Report Descriptor</DataItemName>
+        <DataItemDefinition>Type and characteristics of the data as transmitted by a system.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one octet, followed by one-octet extensions as necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>ATP</BitsShortName>
+                        <BitsName>Address Type</BitsName>
+                        <BitsValue val="0">24-Bit ICAO address</BitsValue>
+                        <BitsValue val="1">Duplicate address</BitsValue>
+                        <BitsValue val="2">Surface vehicle address</BitsValue>
+                        <BitsValue val="3">Anonymous address</BitsValue>
+                        <BitsValue val="4">Reserved for future use</BitsValue>
+                        <BitsValue val="5">Reserved for future use</BitsValue>
+                        <BitsValue val="6">Reserved for future use</BitsValue>
+                        <BitsValue val="7">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>ARC</BitsShortName>
+                        <BitsName>Altitude Reporting Capability</BitsName>
+                        <BitsValue val="0">25 ft</BitsValue>
+                        <BitsValue val="1">100 ft</BitsValue>
+                        <BitsValue val="2">Unknown</BitsValue>
+                        <BitsValue val="3">Invalid</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RC</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Range Check passed, CPR Validation pending</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RAB</BitsShortName>
+                        <BitsName>Report Type</BitsName>
+                        <BitsValue val="0">Report from target transponder</BitsValue>
+                        <BitsValue val="1">Report from field monitor (fixed transponder)</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of item</BitsValue>
+                        <BitsValue val="1">Entension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>DCR</BitsShortName>
+                        <BitsName>Differential Correction</BitsName>
+                        <BitsValue val="0">No differential correction (ADS-B)</BitsValue>
+                        <BitsValue val="1">Differential correction (ADS-B)</BitsValue>
+                    </Bits>
+                    <Bits bit="7">
+                        <BitsShortName>GBS</BitsShortName>
+                        <BitsName>Ground Bit Setting</BitsName>
+                        <BitsValue val="0">Ground Bit not set</BitsValue>
+                        <BitsValue val="1">Ground Bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SIM</BitsShortName>
+                        <BitsName>Simulated Target</BitsName>
+                        <BitsValue val="0">Actual target report</BitsValue>
+                        <BitsValue val="1">Simulated target report</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>TST</BitsShortName>
+                        <BitsName>Test Target</BitsName>
+                        <BitsValue val="0">Default</BitsValue>
+                        <BitsValue val="1">Test Target</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>SAA</BitsShortName>
+                        <BitsName>Selected Altitude Available</BitsName>
+                        <BitsValue val="0">Equipment capable to provide Selected Altitude</BitsValue>
+                        <BitsValue val="1">Equipment not capable to provide Selected Altitude</BitsValue>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>CL</BitsShortName>
+                        <BitsName>Confidence Level</BitsName>
+                        <BitsValue val="0">Report valid</BitsValue>
+                        <BitsValue val="1">Report suspect</BitsValue>
+                        <BitsValue val="2">No information</BitsValue>
+                        <BitsValue val="3">Reserved for future use</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of item</BitsValue>
+                        <BitsValue val="1">Entension into second extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="7">
+                        <BitsShortName>LLC</BitsShortName>
+                        <BitsName>List Lookup Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">List Lookup failed</BitsValue>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>IPC</BitsShortName>
+                        <BitsName>Independent Position Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">Independent Position Check failed</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>NOGO</BitsShortName>
+                        <BitsName>No-go Bit Status</BitsName>
+                        <BitsValue val="0">NOGO-bit not set</BitsValue>
+                        <BitsValue val="1">NOGO-bit set</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>CPR</BitsShortName>
+                        <BitsName>Compact Position Reporting</BitsName>
+                        <BitsValue val="0">CPR Validation correct</BitsValue>
+                        <BitsValue val="1">CPR Validation failed</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>LDPJ</BitsShortName>
+                        <BitsName>Local Decoding Position Jump</BitsName>
+                        <BitsValue val="0">LDPJ not detected</BitsValue>
+                        <BitsValue val="1">LDPJ detected</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>RCF</BitsShortName>
+                        <BitsName>Range Check</BitsName>
+                        <BitsValue val="0">default</BitsValue>
+                        <BitsValue val="1">Range Check failed</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Field Extension</BitsName>
+                        <BitsValue val="0">End of data item</BitsValue>
+                        <BitsValue val="1">Entension into third extent</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+        <DataItemNote>
+1. Bit 3 indicates that the position reported by the target is within a credible range from the ground station. The range check is followed by the CPR validation to ensure that global and local position decoding both indicate valid position information. Bit 3=1 indicates that the range check was done, but the CPR validation is not yet completed. Once CPR validation is completed, Bit 3 will be reset to 0.
+2. The second extension signals the reasons for which the report has been indicated as suspect (indication Confidence Level (CL) in the first extension). Bit 2 indicates that the Range Check failed, i.e. the target is reported outside the credible range for the Ground Station. For operational users such a target will be suppressed. In services used for monitoring the Ground Station, the target will be transmitted with bit 2 indicating the fault condition.
+3. Bit 6, if set to 1, indicates that the position reported by the target was validated by an independent means and a discrepancy was ADS-B Target Reports EUROCONTROL-SPEC-0149-12 Edition : 2.4 Released Edition Page 17 detected. If no independent position check is implemented, the default value '0' is to be used.
+4. Bit 5 represents the setting of the GO/NOGO-bit as defined in item I023/100 of category 023 [Ref. 3].
+5. Bit 7, if set to 1, indicates that a lookup in a Black-list/White-list failed, indicating that the target may be suspect
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="070" rule="optional">
+        <DataItemName>Mode 3/A Code in Octal Representation</DataItemName>
+        <DataItemDefinition>Mode-3/A code converted into octal representation.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to 0</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1" encode="octal">
+                    <BitsShortName>Mode3A</BitsShortName>
+                    <BitsName>Mode-3/A reply in octal</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="071" rule="optional">
+        <DataItemName>Time of Applicability for Position</DataItemName>
+        <DataItemDefinition>Time of applicability of the reported position, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_applicability_position</BitsShortName>
+                    <BitsName>Time of Applicability of Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. The time of applicability value is reset to zero at every midnight. 2. The time of applicability indicates the exact time at which the position transmitted in the target report is valid.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="072" rule="optional">
+        <DataItemName>Time of Applicability for Velocity</DataItemName>
+        <DataItemDefinition>Time of applicability (measurement) of the reported velocity, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_applicability_velocity</BitsShortName>
+                    <BitsName>Time of Applicability of Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. The time of applicability value is reset to zero at every midnight. 2. The time of applicability indicates the exact time at which the velocity information transmitted in the target report is valid. 3. This item will not be available in some ADS-B technologies.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="073" rule="optional">
+        <DataItemName>Time of Message Reception for Position</DataItemName>
+        <DataItemDefinition>Time of reception of the latest position squitter in the Ground Station, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_reception_position</BitsShortName>
+                    <BitsName>Time of Message Reception of Position</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of message reception value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="074" rule="optional">
+        <DataItemName>Time of Message Reception of Position-High Precision</DataItemName>
+        <DataItemDefinition>Time at which the latest ADS-B position information was received by the ground station, expressed as fraction of the second of the UTC Time.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRp whole seconds = (I021/073) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRp whole seconds = (I021/073) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRp whole seconds = (I021/073) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1">
+                    <BitsShortName>time_reception_position_highprecision</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for position in the ground station.</BitsName>
+                    <BitsUnit scale="0.9313225746154785">ns</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="075" rule="optional">
+        <DataItemName>Time of Message Reception for Velocity</DataItemName>
+        <DataItemDefinition>Time of reception of the latest velocity squitter in the Ground Station, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_reception_velocity</BitsShortName>
+                    <BitsName>Time of Message Reception of Velocity</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of message reception value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="076" rule="optional">
+        <DataItemName>Time of Message Reception of Velocity-High Precision</DataItemName>
+        <DataItemDefinition>Time at which the latest ADS-B velocity information was received by the ground station, expressed as fraction of the second of the UTC Time.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits from="32" to="31">
+                    <BitsShortName>FSI</BitsShortName>
+                    <BitsName>Full Second Indication</BitsName>
+                    <BitsValue val="0">TOMRv whole seconds = (I021/073) Whole seconds</BitsValue>
+                    <BitsValue val="1">TOMRv whole seconds = (I021/073) Whole seconds + 1</BitsValue>
+                    <BitsValue val="2">TOMRv whole seconds = (I021/073) Whole seconds - 1</BitsValue>
+                    <BitsValue val="3">Reserved</BitsValue>
+                </Bits>
+                <Bits from="30" to="1">
+                    <BitsShortName>time_reception_velocity_highprecision</BitsShortName>
+                    <BitsName>Fractional part of the time of message reception for velocity in the ground station.</BitsName>
+                    <BitsUnit scale="0.9313225746154785">ns</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="077" rule="optional">
+        <DataItemName>Time of ASTERIX Report Transmission</DataItemName>
+        <DataItemDefinition>Time of the transmission of the ASTERIX category 021 report in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+        <DataItemFormat desc="Three-Octet fixed length data item.">
+            <Fixed length="3">
+                <Bits from="24" to="1">
+                    <BitsShortName>time_report_transmission</BitsShortName>
+                    <BitsName>Time of ASTERIX Report Transmission</BitsName>
+                    <BitsUnit scale="0.0078125">s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The time of ASTERIX report transmission value is reset to zero at every midnight.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="080" rule="mandatory">
+        <DataItemName>Target Address</DataItemName>
+        <DataItemDefinition>Target address (emitter identifier) assigned uniquely to each target.</DataItemDefinition>
+        <DataItemFormat desc="Three-octet fixed length Data Item.">
+            <Fixed length="3">
+                <Bits from="24" to="1" encode="hex">
+                    <BitsShortName>TAddr</BitsShortName>
+                    <BitsName>Target Address</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="090" rule="mandatory">
+        <DataItemName>Quality Indicators</DataItemName>
+        <DataItemDefinition>ADS-B quality indicators transmitted by a/c according to MOPS version.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one- octet, followed by one-octet extents as necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="6">
+                        <BitsShortName>NUCr_or_NACv</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for velocity or Navigation Accuracy Category for Velocity</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NUCp_or_NIC</BitsShortName>
+                        <BitsName>Navigation Uncertainty Category for Position NUCp or Navigation Integrity Category NIC.</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits bit="8">
+                        <BitsShortName>NICbaro</BitsShortName>
+                        <BitsName>Navigation Integrity Category for Barometric Altitude</BitsName>
+                    </Bits>
+                    <Bits from="7" to="6">
+                        <BitsShortName>SIL</BitsShortName>
+                        <BitsName>Surveillance (version 1) or Source (version 2) Integrity Level</BitsName>
+                    </Bits>
+                    <Bits from="5" to="2">
+                        <BitsShortName>NACp</BitsShortName>
+                        <BitsName>Navigation Accuracy Category for Position</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>SILS</BitsShortName>
+                        <BitsValue val="0">Measured per light-hour</BitsValue>
+                        <BitsValue val="1">Measured per sample</BitsValue>
+                    </Bits>
+                    <Bits from="5" to="4">
+                        <BitsShortName>SDA</BitsShortName>
+                        <BitsName>Horizontal Position System Design Assurance Level (as defined in version 2)</BitsName>
+                    </Bits>
+                    <Bits from="3" to="2">
+                        <BitsShortName>GVA</BitsShortName>
+                        <BitsName>Geometric Altitude Accuracy</BitsName>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>PIC</BitsShortName>
+                        <BitsName>Position Integrity Category</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to 0</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension Indicator</BitsName>
+                        <BitsValue val="0">End of Data Item</BitsValue>
+                        <BitsValue val="1">Extension into next extent</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+        <DataItemNote>
+1. The primary subfield is kept for backwards compatibility reasons. Version 2 NIC-values shall be mapped accordingly. This is required to ensure that downstream systems, which are not capable of interpreting extensions 2 and 3 (because they use an ASTERIX edition earlier than 2.0) still get the required information
+2. 'Version 1' or 'Version 2' refers to the MOPS version as defined in data item I021/210, bits 6/4
+3. PIC=0 is defined for completeness only. In this case the third extension shall not be generated.
+4. For ED102A/DO260B PIC values of 7 and 9, the NIC supplements for airborne messages (NIC supplements A/B) and surface messages (NIC supplements A/C) are listed. For ED102A/DO260B PIC=8, the NIC supplements A/B for airborne messages are listed. For DO260A PIC values of 7 and 8, the NIC supplement for airborne messages is shown in brackets. The aircraft air-ground status, and hence message type (airborne or surface), is derived from the GBS-bit in I021/040, 1st extension
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="110" rule="optional">
+        <DataItemName>Trajectory Intent</DataItemName>
+        <DataItemDefinition>Reports indicating the 4D intended trajectory of the aircraft.</DataItemDefinition>
+        <DataItemFormat desc="Compound Data Item, comprising a primary subfield of one octet, followed by the indicated subfields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>TIS</BitsShortName>
+                            <BitsName>Trajectory Intent Status</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TID</BitsShortName>
+                            <BitsName>Trajectory Intent Data</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+                            <BitsValue val="0">End of Data Item</BitsValue>
+                            <BitsValue val="1">Extension into next extent</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>NAV</BitsShortName>
+                            <BitsName>NAV</BitsName>
+                            <BitsValue val="0">Trajectory Intent Data is available for this aircraft</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not available for this aircraft</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>NVB</BitsShortName>
+                            <BitsName>NVB</BitsName>
+                            <BitsValue val="0">Trajectory Intent Data is valid</BitsValue>
+                            <BitsValue val="1">Trajectory Intent Data is not valid</BitsValue>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+                            <BitsValue val="0">End of Data Item</BitsValue>
+                            <BitsValue val="1">Extension into next extent</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Repetitive>
+                    <Fixed length="15">
+                        <Bits bit="120">
+                            <BitsShortName>TCA</BitsShortName>
+                            <BitsValue val="0">TCP number available</BitsValue>
+                            <BitsValue val="1">TCP number not available</BitsValue>
+                        </Bits>
+                        <Bits bit="119">
+                            <BitsShortName>NC</BitsShortName>
+                            <BitsValue val="0">TCP compliance</BitsValue>
+                            <BitsValue val="1">TCP non-compliance</BitsValue>
+                        </Bits>
+                        <Bits from="118" to="113">
+                            <BitsShortName>TcpN</BitsShortName>
+                            <BitsName>Trajectory Change Point Number</BitsName>
+                        </Bits>
+                        <Bits from="112" to="97" encode="signed">
+                            <BitsShortName>Alt</BitsShortName>
+                            <BitsName>Altitude</BitsName>
+                            <BitsUnit scale="10" min="-1500" max="150000">ft</BitsUnit>
+                        </Bits>
+                        <Bits from="96" to="73" encode="signed">
+                            <BitsShortName>Lat</BitsShortName>
+                            <BitsName>Latitude</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="72" to="49" encode="signed">
+                            <BitsShortName>Lon</BitsShortName>
+                            <BitsName>Longitude</BitsName>
+                            <BitsUnit scale="0.000021457672119140625" min="-180" max="180">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="48" to="45">
+                            <BitsShortName>PType</BitsShortName>
+                            <BitsName>Point Type</BitsName>
+                            <BitsValue val="0">Unknown</BitsValue>
+                            <BitsValue val="1">Fly by waypoint (LT)</BitsValue>
+                            <BitsValue val="2">Fly over waypoint (LT)</BitsValue>
+                            <BitsValue val="3">Hold pattern (LT)</BitsValue>
+                            <BitsValue val="4">Procedure hold (LT)</BitsValue>
+                            <BitsValue val="5">Procedure turn (LT)</BitsValue>
+                            <BitsValue val="6">RF leg (LT)</BitsValue>
+                            <BitsValue val="7">Top of climb (VT)</BitsValue>
+                            <BitsValue val="8">Top of descent (VT)</BitsValue>
+                            <BitsValue val="9">Start of level (VT)</BitsValue>
+                            <BitsValue val="10">Cross-over altitude (VT)</BitsValue>
+                            <BitsValue val="11">Transition altitude (VT)</BitsValue>
+                        </Bits>
+                        <Bits from="44" to="43">
+                            <BitsShortName>TD</BitsShortName>
+                            <BitsValue val="0">N/A</BitsValue>
+                            <BitsValue val="1">Turn right</BitsValue>
+                            <BitsValue val="2">Turn left</BitsValue>
+                            <BitsValue val="3">No turn</BitsValue>
+                        </Bits>
+                        <Bits bit="42">
+                            <BitsShortName>TRA</BitsShortName>
+                            <BitsName>Turn Radius Availability</BitsName>
+                            <BitsValue val="0">TTR not available</BitsValue>
+                            <BitsValue val="1">TTR available</BitsValue>
+                        </Bits>
+                        <Bits bit="41">
+                            <BitsShortName>TOA</BitsShortName>
+                            <BitsValue val="0">TOV available</BitsValue>
+                            <BitsValue val="1">TOV not available</BitsValue>
+                        </Bits>
+                        <Bits from="40" to="17">
+                            <BitsShortName>TOV</BitsShortName>
+                            <BitsName>Time Over Point</BitsName>
+                            <BitsUnit scale="1">s</BitsUnit>
+                        </Bits>
+                        <Bits from="16" to="1">
+                            <BitsShortName>TTR</BitsShortName>
+                            <BitsName>TCP Turn radius</BitsName>
+                            <BitsUnit scale="0.01" max="655.35">Nm</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                </Repetitive>
+            </Compound>
+        </DataItemFormat>
+        <DataItemNote>
+1. NC is set to one when the aircraft will not fly the path described by the TCP data.
+2. TCP numbers start from zero.
+3. LT = Lateral Type
+4. VT = Vertical Type
+5. TOV gives the estimated time before reaching the point. It is defined as the absolute time from midnight.
+6. TOV is meaningful only if TOA is set to 1.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="130" rule="optional">
+        <DataItemName>Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>Position in WGS-84 Co-ordinates.</DataItemDefinition>
+        <DataItemFormat desc="Six-octet fixed length Data Item.">
+            <Fixed length="6">
+                <Bits from="25" to="48" encode="signed">
+                    <BitsShortName>Lat</BitsShortName>
+                    <BitsName>Latitude in WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                </Bits>
+                <Bits from="1" to="24" encode="signed">
+                    <BitsShortName>Lon</BitsShortName>
+                    <BitsName>Longitude in WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Positive longitude indicates East. Positive latitude indicates North.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="131" rule="optional">
+        <DataItemName>High-Resolution Position in WGS-84 Co-ordinates</DataItemName>
+        <DataItemDefinition>Position in WGS-84 Co-ordinates in high resolution.</DataItemDefinition>
+        <DataItemFormat desc="Eight-octet fixed length Data Item.">
+            <Fixed length="8">
+                <Bits from="64" to="33" encode="signed">
+                    <BitsShortName>Lat</BitsShortName>
+                    <BitsName>Latitude In WGS.84 in two's complement. Range -90 &lt;= Lat &lt;= 90 deg.</BitsName>
+                    <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
+                </Bits>
+                <Bits from="32" to="1" encode="signed">
+                    <BitsShortName>Lon</BitsShortName>
+                    <BitsName>Longitude In WGS.84 in two's complement. Range -180 &lt;= longitude &lt; 180 deg.</BitsName>
+                    <BitsUnit scale="0.00000016763806343078613">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Positive longitude indicates East. Positive latitude indicates North.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="132" rule="optional">
+        <DataItemName>Message Amplitude</DataItemName>
+        <DataItemDefinition>Amplitude, in dBm, of ADS-B messages received by the ground station, coded in two's complement.</DataItemDefinition>
+        <DataItemFormat desc="One-Octet fixed length data item.">
+            <Fixed length="1">
+                <Bits from="8" to="1" encode="signed">
+                    <BitsShortName>MAM</BitsShortName>
+                    <BitsName>Message Amplitude</BitsName>
+                    <BitsUnit scale="1">dBm</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="140" rule="optional">
+        <DataItemName>Geometric Height</DataItemName>
+        <DataItemDefinition>Minimum height from a plane tangent to the earth's ellipsoid, defined by WGS-84, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>geometric_height</BitsShortName>
+                    <BitsName>Geometric Height</BitsName>
+                    <BitsUnit scale="6.25" min="-1500" max="150000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1. LSB is required to be less than 10 ft by ICAO.
+2. A value of '0111111111111111' indicates that the aircraft transmits a 'greater than' indication.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="145" rule="optional">
+        <DataItemName>Flight Level</DataItemName>
+        <DataItemDefinition>Flight Level from barometric measurements, not QNH corrected, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>FL</BitsShortName>
+                    <BitsName>Flight Level</BitsName>
+                    <BitsUnit scale="0.25" min="-15" max="1500">FL</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="146" rule="optional">
+        <DataItemName>Intermediate State Selected Altitude</DataItemName>
+        <DataItemDefinition>The Selected Altitude as provided by the avionics and corresponding either to the MCP/FCU Selected Altitude (the ATC cleared altitude entered by the flight crew into the avionics) or to the FMS Selected Altitude.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>SAS</BitsShortName>
+                    <BitsName>Source Availability</BitsName>
+                    <BitsValue val="0">No source information provided</BitsValue>
+                    <BitsValue val="1">Source Information provided</BitsValue>
+                </Bits>
+                <Bits from="15" to="14">
+                    <BitsShortName>Source</BitsShortName>
+                    <BitsName>Source</BitsName>
+                    <BitsValue val="0">Unknown</BitsValue>
+                    <BitsValue val="1">Aircraft Altitude (Holding Altitude)</BitsValue>
+                    <BitsValue val="2">FCU/MCP Selected Altitude</BitsValue>
+                    <BitsValue val="3">FMS Selected Altitude</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+                    <BitsShortName>Alt</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1. The Selected Altitude provided in this field is not necessarily the 'Target Altitude' as defined by ICAO.
+2. The value of 'Source' (bits 15/14) indicating 'unknown' or 'Aircraft Altitude' is kept for backward compatibility as these indications are not provided by 'version 2' systems as defined by data item I021/210, bits 6/4.
+3. Vertical mode indications supporting the determination of the nature of the Selected Altitude are provided in the Reserved Expansion Field in the subfield NAV.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="148" rule="optional">
+        <DataItemName>Final State Selected Altitude</DataItemName>
+        <DataItemDefinition>The vertical intent value that corresponds with the ATC cleared altitude, as derived from the Altitude Control Panel (MCP/FCU).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>MV</BitsShortName>
+                    <BitsName>Manage Vertical Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="15">
+                    <BitsShortName>AH</BitsShortName>
+                    <BitsName>Altitude Hold Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits bit="14">
+                    <BitsShortName>AM</BitsShortName>
+                    <BitsName>Approach Mode</BitsName>
+                    <BitsValue val="0">Not active</BitsValue>
+                    <BitsValue val="1">Active</BitsValue>
+                </Bits>
+                <Bits from="13" to="1" encode="signed">
+                    <BitsShortName>Alt</BitsShortName>
+                    <BitsName>Altitude</BitsName>
+                    <BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>This item is kept for backward compatibility but shall not be used for 'version 2' ADS-B systems (as defined by data item I021/210, bits 6/4) for which item 146 will be used to forward the MCP/FCU or the FMS selected altitude information. For 'version 2' ADS-B systems, the vertical mode indications will be provided through the Reserved Expansion Field in the subfield NAV .</DataItemNote>
+    </DataItem>
+
+    <DataItem id="150" rule="optional">
+        <DataItemName>Air Speed</DataItemName>
+        <DataItemDefinition>Calculated Air Speed (Element of Air Vector).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>IM</BitsShortName>
+                    <BitsName>Air Speed type</BitsName>
+                    <BitsValue val="0">Air Speed = IAS</BitsValue>
+                    <BitsValue val="1">Air Speed = Mach</BitsValue>
+                </Bits>
+                <Bits from="15" to="1">
+                    <BitsShortName>ASpeed</BitsShortName>
+                    <BitsName>Air Speed (IAS or Mach)</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="151" rule="optional">
+        <DataItemName>True Air Speed</DataItemName>
+        <DataItemDefinition>True Air Speed.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1">
+                    <BitsShortName>TAS</BitsShortName>
+                    <BitsName>True Air Speed</BitsName>
+                    <BitsUnit scale="1">knot</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the True Air Speed contains the maximum value that can be downloaded from the aircraft avionics and the RE- bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="152" rule="optional">
+        <DataItemName>Magnetic Heading</DataItemName>
+        <DataItemDefinition>Magnetic Heading (Element of Air Vector).</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1">
+                    <BitsShortName>MHdg</BitsShortName>
+                    <BitsName>Magnetic Heading</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>True North Heading is defined in the Reserved Expansion Field in the subfield TNH.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="155" rule="optional">
+        <DataItemName>Barometric Vertical Rate</DataItemName>
+        <DataItemDefinition>Barometric Vertical Rate, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+                    <BitsShortName>BVR</BitsShortName>
+                    <BitsName>Barometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/minute</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Barometric Vertical Rate contains the maximum value that can be downloaded from the aircraft avionics and the RE-bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="157" rule="optional">
+        <DataItemName>Geometric Vertical Rate</DataItemName>
+        <DataItemDefinition>Geometric Vertical Rate, in two's complement form, with reference to WGS-84.</DataItemDefinition>
+        <DataItemFormat desc="Two-Octet fixed length data item.">
+            <Fixed length="2">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="15" to="1" encode="signed">
+                    <BitsShortName>GVR</BitsShortName>
+                    <BitsName>Geometric Vertical Rate</BitsName>
+                    <BitsUnit scale="6.25">feet/minute</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Geometric Vertical Rate contains the maximum value that can be downloaded from the aircraft avionics and the RE-bit indicates that the actual value is greater than the value contained in the field.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="160" rule="optional">
+        <DataItemName>Airborne Ground Vector</DataItemName>
+        <DataItemDefinition>Ground Speed and Track Angle elements of Ground Vector.</DataItemDefinition>
+        <DataItemFormat desc="Four-Octet fixed length data item.">
+            <Fixed length="4">
+                <Bits bit="16">
+                    <BitsShortName>RE</BitsShortName>
+                    <BitsName>Range Exceeded Indicator</BitsName>
+                    <BitsValue val="0">Value in defined range</BitsValue>
+                    <BitsValue val="1">Value exceeds defined range</BitsValue>
+                </Bits>
+                <Bits from="31" to="17">
+                    <BitsShortName>GS</BitsShortName>
+                    <BitsName>Ground Speed referenced to WGS-84</BitsName>
+                    <BitsUnit scale="0.00006103515625">NM/s</BitsUnit>
+                </Bits>
+                <Bits from="16" to="1">
+                    <BitsShortName>TA</BitsShortName>
+                    <BitsName>Track Angle clockwise reference to True North</BitsName>
+                    <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1. The RE-Bit, if set, indicates that the value to be transmitted is beyond the range defined for this specific data item and the applied technology. In this case the Ground Speed contains the maximum value that can be downloaded from the aircraft avionics and the RE- bit indicates that the actual value is greater than the value contained in the field.
+2. The Surface Ground Vector format is defined in the Reserved Expansion Field in the subfield SGV.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="161" rule="optional">
+        <DataItemName>Track Number</DataItemName>
+        <DataItemDefinition>An integer value representing a unique reference to a track record within a particular track file.</DataItemDefinition>
+        <DataItemFormat desc="Two-octet fixed length Data Item.">
+            <Fixed length="2">
+                <Bits from="16" to="13">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="12" to="1">
+                    <BitsShortName>TrackN</BitsShortName>
+                    <BitsName>Track number</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="165" rule="optional">
+        <DataItemName>Track Angle Rate</DataItemName>
+        <DataItemDefinition>Rate of Turn, in two's complement form.</DataItemDefinition>
+        <DataItemFormat desc="2-Byte Fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="11">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits from="10" to="1">
+                    <BitsShortName>TA_rate</BitsShortName>
+                    <BitsName>Track Angle Rate</BitsName>
+                    <BitsUnit scale="0.03125">deg/s</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1. A positive value represents a right turn, whereas a negative value represents a left turn.
+2. 'Maximum value' means Maximum value or above.
+3. This item will not be transmitted for the technology '1090 MHz Extended Squitter'.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="170" rule="optional">
+        <DataItemName>Target Identification</DataItemName>
+        <DataItemDefinition>Target (aircraft or vehicle) identification in 8 characters, as reported by the target.</DataItemDefinition>
+        <DataItemFormat desc="Six-octet fixed length Data Item.">
+            <Fixed length="6">
+                <Bits from="48" to="1" encode="6bitschar">
+                    <BitsShortName>TId</BitsShortName>
+                    <BitsName>Characters 1-8 (coded on 6 Bits each) defining target identification when flight plan is available or the registration marking when no flight plan is available. Coding rules are provided in [6] Section 3.1.2.9.1.2 and Table 3-9.</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="200" rule="optional">
+        <DataItemName>Target Status</DataItemName>
+        <DataItemDefinition>Status of the target</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>ICF</BitsShortName>
+                    <BitsName>Intent Change Flag</BitsName>
+                    <BitsValue val="0">No intent change active</BitsValue>
+                    <BitsValue val="1">Intent change flag raised</BitsValue>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>LNAV</BitsShortName>
+                    <BitsName>LNAV Mode</BitsName>
+                    <BitsValue val="0">LNAV Mode engaged</BitsValue>
+                    <BitsValue val="1">LNAV Mode not engaged</BitsValue>
+                </Bits>
+                <Bits bit="6">
+                    <BitsShortName>ME</BitsShortName>
+                    <BitsName>Military emergency</BitsName>
+                    <BitsValue val="0">No military emergency</BitsValue>
+                    <BitsValue val="1">Military emergency/BitsValue></BitsValue>
+                </Bits>
+                <Bits from="5" to="3">
+                    <BitsShortName>PS</BitsShortName>
+                    <BitsName>Priority Status</BitsName>
+                    <BitsValue val="0">No emergency / not reported</BitsValue>
+                    <BitsValue val="1">General emergency</BitsValue>
+                    <BitsValue val="2">Lifeguard / medical emergency</BitsValue>
+                    <BitsValue val="3">Minimum fuel</BitsValue>
+                    <BitsValue val="4">No communications</BitsValue>
+                    <BitsValue val="5">Unlawful interference</BitsValue>
+                    <BitsValue val="6">Downed Aircraft</BitsValue>
+                </Bits>
+                <Bits from="2" to="1">
+                    <BitsShortName>SS</BitsShortName>
+                    <BitsName>Surveillance Status</BitsName>
+                    <BitsValue val="0">No condition reported</BitsValue>
+                    <BitsValue val="1">Permanent Alert (Emergency condition)</BitsValue>
+                    <BitsValue val="2">Temporary Alert (change in Mode 3/A Code other than emergency)</BitsValue>
+                    <BitsValue val="3">SPI set</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Bit-8 (ICF), when set to '1' indicates that new information is available in the Mode S GICB registers 40, 41 or 42.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="210" rule="optional">
+        <DataItemName>MOPS Version</DataItemName>
+        <DataItemDefinition>Identification of the MOPS version used by a/c to supply ADS-B information.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item">
+            <Fixed length="1">
+                <Bits bit="8">
+                    <BitsShortName>spare</BitsShortName>
+                    <BitsName>Spare bits set to zero</BitsName>
+                    <BitsConst>0</BitsConst>
+                </Bits>
+                <Bits bit="7">
+                    <BitsShortName>VNS</BitsShortName>
+                    <BitsName>Version Not Supported</BitsName>
+                    <BitsValue val="0">The MOPS Version is supported by the GS</BitsValue>
+                    <BitsValue val="1">The MOPS Version is not supported by the GS</BitsValue>
+                </Bits>
+                <Bits from="6" to="4">
+                    <BitsShortName>VN</BitsShortName>
+                    <BitsName>Version Number</BitsName>
+                    <BitsValue val="0">DO-260 [Ref. 8]</BitsValue>
+                    <BitsValue val="1">DO-260A [Ref. 9]</BitsValue>
+                    <BitsValue val="2">DO-260B</BitsValue>
+                </Bits>
+                <Bits from="3" to="1">
+                    <BitsShortName>LTT</BitsShortName>
+                    <BitsName>Link Technology Type</BitsName>
+                    <BitsValue val="0">Other</BitsValue>
+                    <BitsValue val="1">UAT</BitsValue>
+                    <BitsValue val="2">1090 ES</BitsValue>
+                    <BitsValue val="3">VDL 4</BitsValue>
+                    <BitsValue val="4">Not assigned</BitsValue>
+                    <BitsValue val="5">Not assigned</BitsValue>
+                    <BitsValue val="6">Not assigned</BitsValue>
+                    <BitsValue val="7">Not assigned</BitsValue>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>Bit 7 (VNS) when set to 1 indicates that the aircraft transmits a MOPS Version indication that is not supported by the Ground Station. However, since MOPS versions are supposed to be backwards compatible, the GS has attempted to interpret the message and achieved a credible result. The fact that the MOPS version received is not supported by the GS is submitted as additional information to subsequent processing systems.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="220" rule="optional">
+        <DataItemName>Met Information</DataItemName>
+        <DataItemDefinition>Meteorological information.</DataItemDefinition>
+        <DataItemFormat desc="Compound data item consisting of a one byte primary sub-field, followed by up to four fixed length data fields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>WS</BitsShortName>
+                            <BitsName>Wind speed</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>WD</BitsShortName>
+                            <BitsName>Wind Direction</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TMP</BitsShortName>
+                            <BitsName>Temperature</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TRB</BitsShortName>
+                            <BitsName>Turbulence</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits from="4" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Fixed length="2">
+                    <Bits from="16" to="1">
+                        <BitsShortName>WindS</BitsShortName>
+                        <BitsName>Wind Speed</BitsName>
+                        <BitsUnit scale="1" min="0" max="300">knot</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="2">
+                    <Bits from="16" to="1">
+                        <BitsShortName>WindD</BitsShortName>
+                        <BitsName>Wind Direction</BitsName>
+                        <BitsUnit scale="1" min="1" max="360">deg</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="2">
+                    <Bits from="16" to="1" encode="signed">
+                        <BitsShortName>Temp</BitsShortName>
+                        <BitsName>Temperature</BitsName>
+                        <BitsUnit scale="0.25" min="-100" max="100">C</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>Turb</BitsShortName>
+                        <BitsName>Turbulence</BitsName>
+                    </Bits>
+                </Fixed>
+            </Compound>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="230" rule="optional">
+        <DataItemName>Roll Angle</DataItemName>
+        <DataItemDefinition>The roll angle, in two's complement form, of an aircraft executing a turn.</DataItemDefinition>
+        <DataItemFormat desc="A two byte fixed length data item.">
+            <Fixed length="2">
+                <Bits from="16" to="1" encode="signed">
+                    <BitsShortName>RollA</BitsShortName>
+                    <BitsName>Roll Angle</BitsName>
+                    <BitsUnit scale="0.01" min="-180" max="180">deg</BitsUnit>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>1. Negative Value indicates 'Left Wing Down'. 2. Resolution provided by the technology '1090 MHz Extended Squitter' is 1 degree.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="250" rule="mandatory">
+        <DataItemName>Mode S MB Data</DataItemName>
+        <DataItemDefinition>Mode S Comm B data as extracted from the aircraft transponder.</DataItemDefinition>
+        <DataItemFormat desc="Repetitive Data Item starting with a one-octet Field Repetition Indicator (REP) followed by at least one BDS message comprising one seven octet BDS register and one octet BDS code.">
+            <Repetitive>
+                <BDS/>
+            </Repetitive>
+        </DataItemFormat>
+        <DataItemNote>
+1. For the transmission of BDS20, item 170 should be used.
+2. For the transmission of BDS30, item 260 is used.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="260" rule="mandatory">
+        <DataItemName>ACAS Resolution Advisory Report</DataItemName>
+        <DataItemDefinition>Currently active Resolution Advisory (RA), if any, generated by the ACAS associated with the transponder transmitting the RA message and threat identity data.</DataItemDefinition>
+        <DataItemFormat desc="Seven-octet fixed length Data Item.">
+            <Fixed length="7">
+                <Bits from="56" to="52">
+                    <BitsShortName>TYP</BitsShortName>
+                    <BitsName>Message Type</BitsName>
+                </Bits>
+                <Bits from="51" to="49">
+                    <BitsShortName>STYP</BitsShortName>
+                    <BitsName>Message Sub-Type</BitsName>
+                </Bits>
+                <Bits from="48" to="35">
+                    <BitsShortName>ARA</BitsShortName>
+                    <BitsName>Active Resolution Advisories</BitsName>
+                </Bits>
+                <Bits from="34" to="31">
+                    <BitsShortName>RAC</BitsShortName>
+                    <BitsName>RAC (RA Complement) Record</BitsName>
+                </Bits>
+                <Bits bit="30">
+                    <BitsShortName>RAT</BitsShortName>
+                    <BitsName>RA Terminated</BitsName>
+                </Bits>
+                <Bits bit="29">
+                    <BitsShortName>MTE</BitsShortName>
+                    <BitsName>Multiple Threat Encounter</BitsName>
+                </Bits>
+                <Bits from="28" to="27">
+                    <BitsShortName>TTI</BitsShortName>
+                    <BitsName>Threat Type Indicator</BitsName>
+                </Bits>
+                <Bits from="26" to="1">
+                    <BitsShortName>TID</BitsShortName>
+                    <BitsName>Threat Identity Data</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+        <DataItemNote>
+1. Version denotes the MOPS version as defined in I021/210, bits 6/4
+2. This data items copies the value of BDS register 6,1 for message type 28, subtype 2
+3. The 'TYP' and 'STYP' items are implementation (i.e. link technology) dependent.
+4. Refer to ICAO Annex 10 SARPs for detailed explanations [Ref. 10].
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="271" rule="optional">
+        <DataItemName>Surface Capabilities and Characteristics</DataItemName>
+        <DataItemDefinition>Operational capabilities of the aircraft while on the ground.</DataItemDefinition>
+        <DataItemFormat desc="Variable Length Data Item, comprising a primary subfield of one-octet, followed by an one-octet extents if necessary.">
+            <Variable>
+                <Fixed length="1">
+                    <Bits from="8" to="7">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to zero</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="6">
+                        <BitsShortName>POA</BitsShortName>
+                        <BitsName>Position Offset Applied</BitsName>
+                        <BitsValue val="0">Position transmitted is not ADS-B position reference point</BitsValue>
+                        <BitsValue val="1">Position transmitted is the ADS-B position reference point</BitsValue>
+                    </Bits>
+                    <Bits bit="5">
+                        <BitsShortName>CDTI_S</BitsShortName>
+                        <BitsName>Cockpit Display of Traffic Information Surface</BitsName>
+                        <BitsValue val="0">CDTI not operational</BitsValue>
+                        <BitsValue val="1">CDTI operational</BitsValue>
+                    </Bits>
+                    <Bits bit="4">
+                        <BitsShortName>B2_low</BitsShortName>
+                        <BitsName>Class B2 transmit power less than 70 Watts</BitsName>
+                        <BitsValue val="0">&gt;= 70 Watts</BitsValue>
+                        <BitsValue val="1">&lt; 70 Watts</BitsValue>
+                    </Bits>
+                    <Bits bit="3">
+                        <BitsShortName>RAS</BitsShortName>
+                        <BitsName>Receiving ATC Services</BitsName>
+                        <BitsValue val="0">Aircraft not receiving ATC-services</BitsValue>
+                        <BitsValue val="1">Aircraft receiving ATC services</BitsValue>
+                    </Bits>
+                    <Bits bit="2">
+                        <BitsShortName>IDENT</BitsShortName>
+                        <BitsName>Setting of 'IDENT'-switch</BitsName>
+                        <BitsValue val="0">IDENT switch not active</BitsValue>
+                        <BitsValue val="1">IDENT switch active</BitsValue>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>FX Extension indicator</BitsName>
+                        <BitsValue val="0">no extension</BitsValue>
+                        <BitsValue val="1">extension into first extent</BitsValue>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="8" to="5">
+                        <BitsShortName>LW</BitsShortName>
+                        <BitsName>Length and width of the aircraft</BitsName>
+                    </Bits>
+                    <Bits from="4" to="2">
+                        <BitsShortName>spare</BitsShortName>
+                        <BitsName>Spare bits set to zero</BitsName>
+                        <BitsConst>0</BitsConst>
+                    </Bits>
+                    <Bits bit="1" fx="1">
+                        <BitsShortName>FX</BitsShortName>
+                        <BitsName>Extension indicator</BitsName>
+                        <BitsValue val="0">no extension</BitsValue>
+                        <BitsValue val="1">extension</BitsValue>
+                    </Bits>
+                </Fixed>
+            </Variable>
+        </DataItemFormat>
+        <DataItemNote>
+1. Version 2 (as defined in I021/210, bits 6/4) data technology protocols encode 'No Data or Unknown' with value 0. In this case data item I021/271, first extension is not generated.
+2. As of edition 2.2 the structure of this data item has been changed. Edition 2.2 is not backwards compatible with previous editions.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="295" rule="optional">
+        <DataItemName>Data Ages</DataItemName>
+        <DataItemDefinition>Ages of the data provided.</DataItemDefinition>
+        <DataItemFormat desc="Compound Data Item, comprising a primary subfield of up to five octets, followed by the indicated subfields.">
+            <Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>AOS</BitsShortName>
+                            <BitsName>Aircraft Operational Status age</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>TRD</BitsShortName>
+                            <BitsName>Target Report Descriptor age</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>M3A</BitsShortName>
+                            <BitsName>Mode 3/A Code age</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>QI</BitsShortName>
+                            <BitsName>Quality Indicators age</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TI</BitsShortName>
+                            <BitsName>Trajectory Intent age</BitsName>
+                            <BitsPresence>5</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MAM</BitsShortName>
+                            <BitsName>Message Amplitude age</BitsName>
+                            <BitsPresence>6</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>GH</BitsShortName>
+                            <BitsName>Geometric Height age</BitsName>
+                            <BitsPresence>7</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>FL</BitsShortName>
+                            <BitsName>Flight Level age</BitsName>
+                            <BitsPresence>8</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>ISA</BitsShortName>
+                            <BitsName>Intermediate State Selected Altitude age</BitsName>
+                            <BitsPresence>9</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>FSA</BitsShortName>
+                            <BitsName>Final State Selected Altitude age</BitsName>
+                            <BitsPresence>10</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>AS</BitsShortName>
+                            <BitsName>Air Speed age</BitsName>
+                            <BitsPresence>11</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TAS</BitsShortName>
+                            <BitsName>True Air Speed age</BitsName>
+                            <BitsPresence>12</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MH</BitsShortName>
+                            <BitsName>Magnetic Heading age</BitsName>
+                            <BitsPresence>13</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>BVR</BitsShortName>
+                            <BitsName>Barometric Vertical Rate age</BitsName>
+                            <BitsPresence>14</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>GVR</BitsShortName>
+                            <BitsName>Geometric Vertical Rate age</BitsName>
+                            <BitsPresence>15</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>GV</BitsShortName>
+                            <BitsName>Ground Vector age</BitsName>
+                            <BitsPresence>16</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>TAR</BitsShortName>
+                            <BitsName>Track Angle Rate age</BitsName>
+                            <BitsPresence>17</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>TID</BitsShortName>
+                            <BitsName>Target Identification age</BitsName>
+                            <BitsPresence>18</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>TS</BitsShortName>
+                            <BitsName>Target Status age</BitsName>
+                            <BitsPresence>19</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>MET</BitsShortName>
+                            <BitsName>Met Information age</BitsName>
+                            <BitsPresence>20</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>ROA</BitsShortName>
+                            <BitsName>Roll Angle age</BitsName>
+                            <BitsPresence>21</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>ARA</BitsShortName>
+                            <BitsName>ACAS Resolution Advisory age</BitsName>
+                            <BitsPresence>22</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>SCC</BitsShortName>
+                            <BitsName>Surface Capabilities and Characteristics age</BitsName>
+                            <BitsPresence>23</BitsPresence>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                </Variable>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>AOS</BitsShortName>
+                        <BitsName>Age of the latest received information transmitted in item I021/008.</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TRD</BitsShortName>
+                        <BitsName>Age of the Target Report Descriptor, item I021/040</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>M3A</BitsShortName>
+                        <BitsName>Age of the Mode 3/A Code, item I021/070</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>QI</BitsShortName>
+                        <BitsName>Age of the Quality Indicators, item I021/090</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TI</BitsShortName>
+                        <BitsName>Age of the Trajectory Intent information, item I021/110</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MAM</BitsShortName>
+                        <BitsName>Age of the message amplitude, item I021/132</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GH</BitsShortName>
+                        <BitsName>Age of the Geometric Height, item 021/140</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>FL</BitsShortName>
+                        <BitsName>Age of the Flight Level, item I021/145</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ISA</BitsShortName>
+                        <BitsName>Age of the Intermediate State Selected Altitude, item I021/146</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>FSA</BitsShortName>
+                        <BitsName>Age of the Final State Selected Altitude, item I021/148</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>AS</BitsShortName>
+                        <BitsName>Age of the Air Speed contained, item I021/150</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TAS</BitsShortName>
+                        <BitsName>Age of the value for the True Air Speed, item I021/151</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MH</BitsShortName>
+                        <BitsName>Age of the value for the Magnetic Heading, item I021/152</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>BVR</BitsShortName>
+                        <BitsName>Age of the Barometric Vertical Rate contained, I021/155</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GVR</BitsShortName>
+                        <BitsName>Age of the Geometric Vertical Rate, item I021/157</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>GV</BitsShortName>
+                        <BitsName>Age of the Ground Vector, item I021/160</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TAR</BitsShortName>
+                        <BitsName>Age of the Track Angle Rate, item I021/165</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TID</BitsShortName>
+                        <BitsName>Age of the Target Identification, item I021/170</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>TS</BitsShortName>
+                        <BitsName>Age of the Target Status as contained, item I021/200</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>MET</BitsShortName>
+                        <BitsName>Age of the Meteorological information, I021/220</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ROA</BitsShortName>
+                        <BitsName>Age of the Roll Angle, item I021/230</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>ARA</BitsShortName>
+                        <BitsName>Age of the latest update of an active ACAS Resolution Advisory, item I021/260</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+                <Fixed length="1">
+                    <Bits from="1" to="8">
+                        <BitsShortName>SCC</BitsShortName>
+                        <BitsName>Age of the information on the surface capabilities and characteristics of the respective target, item I021/271</BitsName>
+                        <BitsUnit scale="0.1" max="25.5">s</BitsUnit>
+                    </Bits>
+                </Fixed>
+            </Compound>
+        </DataItemFormat>
+        <DataItemNote>1. In all the subfields, the maximum value indicates 'maximum value or above'.</DataItemNote>
+    </DataItem>
+
+    <DataItem id="400" rule="optional">
+        <DataItemName>Receiver ID</DataItemName>
+        <DataItemDefinition>Designator of Ground Station in Distributed System.</DataItemDefinition>
+        <DataItemFormat desc="One-octet fixed length Data Item.">
+            <Fixed length="1">
+                <Bits from="8" to="1">
+                    <BitsShortName>RID</BitsShortName>
+                    <BitsName>Receiver ID</BitsName>
+                </Bits>
+            </Fixed>
+        </DataItemFormat>
+    </DataItem>
+
+    <DataItem id="RE">
+        <DataItemName>Reserved Expansion Field</DataItemName>
+        <DataItemDefinition>Reserved Expansion Field of ASTERIX Cat 021 (ADS-B Reports)</DataItemDefinition>
+        <DataItemFormat desc="One byte length field, followed by a one byte items indicator and the encoded items.">
+            <Explicit>
+                <Compound>
+                    <Variable>
+                        <Fixed length="1">
+                            <Bits bit="8">
+                                <BitsShortName>BPS</BitsShortName>
+                                <BitsName>Barometric Pressure Setting</BitsName>
+                                <BitsPresence>1</BitsPresence>
+                            </Bits>
+                            <Bits bit="7">
+                                <BitsShortName>SelH</BitsShortName>
+                                <BitsName>Selected Heading</BitsName>
+                                <BitsPresence>2</BitsPresence>
+                            </Bits>
+                            <Bits bit="6">
+                                <BitsShortName>NAV</BitsShortName>
+                                <BitsName>Navigation Mode</BitsName>
+                                <BitsPresence>3</BitsPresence>
+                            </Bits>
+                            <Bits bit="5">
+                                <BitsShortName>GAO</BitsShortName>
+                                <BitsName>GPS Antenna Offset</BitsName>
+                                <BitsPresence>4</BitsPresence>
+                            </Bits>
+                            <Bits bit="4">
+                                <BitsShortName>SGV</BitsShortName>
+                                <BitsName>Surface Ground Vector</BitsName>
+                                <BitsPresence>5</BitsPresence>
+                            </Bits>
+                            <Bits bit="3">
+                                <BitsShortName>STA</BitsShortName>
+                                <BitsName>Aircraft Status Information</BitsName>
+                                <BitsPresence>6</BitsPresence>
+                            </Bits>
+                            <Bits bit="2">
+                                <BitsShortName>TNH</BitsShortName>
+                                <BitsName>True North Heading</BitsName>
+                                <BitsPresence>7</BitsPresence>
+                            </Bits>
+                            <Bits bit="1">
+                                <BitsShortName>MES</BitsShortName>
+                                <BitsName>Military Extended Squitters</BitsName>
+                                <BitsConst>0</BitsConst>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+                    <Fixed length="2">
+                        <Bits from="16" to="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="12" to="1">
+                            <BitsShortName>BPS</BitsShortName>
+                            <BitsName>Barometric Pressure Setting</BitsName>
+                            <BitsUnit scale="0.1" max="409.5">mb</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits from="16" to="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="12">
+                            <BitsShortName>SelHHRD</BitsShortName>
+                            <BitsName>SelH Horizontal Reference Direction</BitsName>
+                            <BitsValue val="0">True North.</BitsValue>
+                            <BitsValue val="1">Magnetic North.</BitsValue>
+                        </Bits>
+                        <Bits bit="11">
+                            <BitsShortName>Stat</BitsShortName>
+                            <BitsName>Selected Heading Status</BitsName>
+                            <BitsValue val="0">Data is either unavailable or invalid.</BitsValue>
+                            <BitsValue val="1">Data is available and valid.</BitsValue>
+                        </Bits>
+                        <Bits from="10" to="1">
+                            <BitsShortName>SelH</BitsShortName>
+                            <BitsName>Selected Heading</BitsName>
+                            <BitsUnit scale="0.703125">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>AP</BitsShortName>
+                            <BitsName>Autopilot engaged</BitsName>
+                            <BitsValue val="0">Not Autopilot engaged.</BitsValue>
+                            <BitsValue val="1">Autopilot engaged.</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>VN</BitsShortName>
+                            <BitsName>VNAV Active (Vertical Navigation)</BitsName>
+                            <BitsValue val="0">Not VNAV Active.</BitsValue>
+                            <BitsValue val="1">VNAV Active.</BitsValue>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>AH</BitsShortName>
+                            <BitsName>Altitude Hold engaged</BitsName>
+                            <BitsValue val="0">Not Altitude Hold.</BitsValue>
+                            <BitsValue val="1">Altitude Hold.</BitsValue>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>AM</BitsShortName>
+                            <BitsName>Approach Mode active</BitsName>
+                            <BitsValue val="0">Not Approach Mode.</BitsValue>
+                            <BitsValue val="1">Approach Mode.</BitsValue>
+                        </Bits>
+                        <Bits from="4" to="1">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="8" to="1">
+                            <BitsShortName>GAO</BitsShortName>
+                            <BitsName>GPS Antenna Offset</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Variable>
+                        <Fixed length="2">
+                            <Bits bit="16">
+                                <BitsShortName>STP</BitsShortName>
+                                <BitsName>Aircraft stopped</BitsName>
+                                <BitsValue val="0">Aircraft has not stopped.</BitsValue>
+                                <BitsValue val="1">Aircraft has stopped.</BitsValue>
+                            </Bits>
+                            <Bits bit="15">
+                                <BitsShortName>HTS</BitsShortName>
+                                <BitsName>Heading/Ground Track</BitsName>
+                                <BitsValue val="0">Heading/Ground Track is not valid.</BitsValue>
+                                <BitsValue val="1">Heading/Ground Track is valid.</BitsValue>
+                            </Bits>
+                            <Bits bit="14">
+                                <BitsShortName>HTT</BitsShortName>
+                                <BitsName>Heading/Ground data</BitsName>
+                                <BitsValue val="0">Heading data provided.</BitsValue>
+                                <BitsValue val="1">Ground Track provided.</BitsValue>
+                            </Bits>
+                            <Bits bit="13">
+                                <BitsShortName>SVGHRD</BitsShortName>
+                                <BitsName>SVG Horizontal Reference Direction</BitsName>
+                                <BitsValue val="0">True North.</BitsValue>
+                                <BitsValue val="1">Magnetic North.</BitsValue>
+                            </Bits>
+                            <Bits from="12" to="2">
+                                <BitsShortName>GSS</BitsShortName>
+                                <BitsName>Ground Speed</BitsName>
+                                <BitsUnit scale="0.125">kts</BitsUnit>
+                            </Bits>
+                            <Bits bit="1" fx="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension indicator</BitsName>
+                                <BitsValue val="0">no extension</BitsValue>
+                                <BitsValue val="1">extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                        <Fixed length="1">
+                            <Bits from="8" to="2">
+                                <BitsShortName>HGT</BitsShortName>
+                                <BitsName>Heading/Ground Track information</BitsName>
+                                <BitsUnit scale="2.8125">deg</BitsUnit>
+                            </Bits>
+                            <Bits bit="1" fx="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension indicator</BitsName>
+                                <BitsValue val="0">no extension</BitsValue>
+                                <BitsValue val="1">extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>ES</BitsShortName>
+                            <BitsName>1090 ES IN capability</BitsName>
+                            <BitsValue val="0">Target is not 1090 ES IN capable.</BitsValue>
+                            <BitsValue val="1">Target is 1090 ES IN capable.</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>UAT</BitsShortName>
+                            <BitsName>UAT capability</BitsName>
+                            <BitsValue val="0">Target is not UAT IN capable.</BitsValue>
+                            <BitsValue val="1">Target is UAT IN capable.</BitsValue>
+                        </Bits>
+                        <Bits from="6" to="2">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to zero</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension indicator</BitsName>
+                            <BitsValue val="0">no extension</BitsValue>
+                            <BitsValue val="1">extension</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits from="16" to="1">
+                            <BitsShortName>TNH</BitsShortName>
+                            <BitsName>True North Magnetic Heading</BitsName>
+                            <BitsUnit scale="0.0054931640625">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Variable>
+                        <Fixed length="1">
+                            <Bits bit="8">
+                                <BitsShortName>SUM</BitsShortName>
+                                <BitsName>Mode 5 Summary</BitsName>
+                                <BitsPresence>1</BitsPresence>
+                            </Bits>
+                            <Bits bit="7">
+                                <BitsShortName>PNO</BitsShortName>
+                                <BitsName>Mode 5 PIN/National Origin</BitsName>
+                                <BitsPresence>2</BitsPresence>
+                            </Bits>
+                            <Bits bit="6">
+                                <BitsShortName>EM1</BitsShortName>
+                                <BitsName>Extended Mode 1 Code in Octal Representation</BitsName>
+                                <BitsPresence>3</BitsPresence>
+                            </Bits>
+                            <Bits bit="5">
+                                <BitsShortName>XP</BitsShortName>
+                                <BitsName>X Pulse Presence</BitsName>
+                                <BitsPresence>4</BitsPresence>
+                            </Bits>
+                            <Bits bit="4">
+                                <BitsShortName>FOM</BitsShortName>
+                                <BitsName>Figure of Merit</BitsName>
+                                <BitsPresence>5</BitsPresence>
+                            </Bits>
+                            <Bits bit="3">
+                                <BitsShortName>M2</BitsShortName>
+                                <BitsName>Mode 2 Code</BitsName>
+                                <BitsPresence>6</BitsPresence>
+                            </Bits>
+                            <Bits bit="2">
+                                <BitsShortName>spare</BitsShortName>
+                                <BitsName>Spare bit, set to “0”</BitsName>
+                                <BitsPresence>7</BitsPresence>
+                            </Bits>
+                            <Bits bit="1">
+                                <BitsShortName>FX</BitsShortName>
+                                <BitsName>Extension indicator</BitsName>
+                                <BitsValue val="0">no extension</BitsValue>
+                                <BitsValue val="1">extension</BitsValue>
+                            </Bits>
+                        </Fixed>
+                    </Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>M5</BitsShortName>
+                            <BitsName>Mode 5 interrogation</BitsName>
+                            <BitsValue val="0">No Mode 5 interrogation</BitsValue>
+                            <BitsValue val="1">Mode 5 interrogation</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>ID</BitsShortName>
+                            <BitsName>Authenticated Mode 5 ID</BitsName>
+                            <BitsValue val="0">No authenticated Mode 5 ID reply/report</BitsValue>
+                            <BitsValue val="1">Authenticated Mode 5 ID reply/report</BitsValue>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>DA</BitsShortName>
+                            <BitsName>Authenticated Mode 5 Data reply or Report</BitsName>
+                            <BitsValue val="0">No authenticated Mode 5 Data reply or Report</BitsValue>
+                            <BitsValue val="1">Authenticated Mode 5 Data reply or Report</BitsValue>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>M1</BitsShortName>
+                            <BitsName>Mode 1 code</BitsName>
+                            <BitsValue val="0">Mode 1 code not present or not from Mode 5 reply/report</BitsValue>
+                            <BitsValue val="1">Mode 1 code from Mode 5 reply/report</BitsValue>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>M2</BitsShortName>
+                            <BitsName>Mode 2 code</BitsName>
+                            <BitsValue val="0">Mode 2 code not present or not from Mode 5 reply/report</BitsValue>
+                            <BitsValue val="1">Mode 2 code from Mode 5 reply/report</BitsValue>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>M3</BitsShortName>
+                            <BitsName>Mode 3 code</BitsName>
+                            <BitsValue val="0">Mode 3 code not present or not from Mode 5 reply/report</BitsValue>
+                            <BitsValue val="1">Mode 3 code from Mode 5 reply/report</BitsValue>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>MC</BitsShortName>
+                            <BitsName>Flightlevel</BitsName>
+                            <BitsValue val="0">Flightlevel not present or not from Mode 5 reply/report</BitsValue>
+                            <BitsValue val="1">Flightlevel from Mode 5 reply/report</BitsValue>
+                        </Bits>
+                        <Bits bit="1">
+                            <BitsShortName>PO</BitsShortName>
+                            <BitsName>Position from Mode 5 Report</BitsName>
+                            <BitsValue val="0">Position not from Mode 5 report (ADS-B report)</BitsValue>
+                            <BitsValue val="1">Position from Mode 5 report</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="4">
+                        <Bits from="32" to="31">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="30" to="17">
+                            <BitsShortName>PIN</BitsShortName>
+                            <BitsName>PIN Code</BitsName>
+                        </Bits>
+                        <Bits from="16" to="12">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="11" to="1">
+                            <BitsShortName>NO</BitsShortName>
+                            <BitsName>National Origin Code</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits bit="16">
+                            <BitsShortName>V</BitsShortName>
+                            <BitsName>Code validated</BitsName>
+                            <BitsValue val="0">Code validated</BitsValue>
+                            <BitsValue val="1">Code not validated</BitsValue>
+                        </Bits>
+                        <Bits bit="15">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="14">
+                            <BitsShortName>L</BitsShortName>
+                            <BitsName>Mode 1 code from transponder or smoothed</BitsName>
+                            <BitsValue val="0">Mode 1 code as derived from the report of the transponder</BitsValue>
+                            <BitsValue val="1">Smoothed Mode 1 code as provided by a local tracker</BitsValue>
+                        </Bits>
+                        <Bits bit="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="12" to="1">
+                            <BitsShortName>EM1</BitsShortName>
+                            <BitsName>Extended Mode 1 Code in octal representation</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="8" to="7">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>XP</BitsShortName>
+                            <BitsName>X-pulse from Mode 5 PIN reply/report</BitsName>
+                            <BitsValue val="0">X-Pulse not present</BitsValue>
+                            <BitsValue val="1">X-pulse present</BitsValue>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>X5</BitsShortName>
+                            <BitsName>X-pulse from Mode 5 Data reply or Report.</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no authenticated Data reply or Report received.</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present).</BitsValue>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>XC</BitsShortName>
+                            <BitsName>X-pulse from Mode C reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode C reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>X3</BitsShortName>
+                            <BitsName>X-pulse from Mode 3/A reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 3/A reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>X2</BitsShortName>
+                            <BitsName>X-pulse from Mode 2 reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 2 reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="1">
+                            <BitsShortName>X1</BitsShortName>
+                            <BitsName>X-pulse from Mode 1 reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 1 reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="8" to="6">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="1">
+                            <BitsShortName>FOM</BitsShortName>
+                            <BitsName>Figure of Merit Position Accuracy as extracted and provided by a Mode 5 transponder</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits bit="16">
+                            <BitsShortName>V</BitsShortName>
+                            <BitsName>Code validated</BitsName>
+                            <BitsValue val="0">Code validated</BitsValue>
+                            <BitsValue val="1">Code validated</BitsValue>
+                        </Bits>
+                        <Bits bit="15">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="14">
+                            <BitsShortName>L</BitsShortName>
+                            <BitsName>Mode 2 code from transponder or smoothed</BitsName>
+                            <BitsValue val="0">Mode-2 code as derived from the reply of the transponder</BitsValue>
+                            <BitsValue val="1">Smoothed Mode-2 code as provided by a local tracker</BitsValue>
+                        </Bits>
+                        <Bits bit="13">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>Spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="12" to="1">
+                            <BitsShortName>M2CO</BitsShortName>
+                            <BitsName>Mode-2 code in octal representation</BitsName>
+                        </Bits>
+                    </Fixed>
+                </Compound>
+            </Explicit>
+        </DataItemFormat>
+        <DataItemNote>
+BPS
+1. BPS is the barometric pressure setting of the aircraft minus 800 mb.
+2. A value of "0" indicates that in the aircraft a value of 800mb or less has been selected.
+3. A value of "409.5" indicates that in the aircraft a value of 1209.5mb or more has been selected.
+SelH
+1. On many aircraft, the ADS-B Transmitting Subsystem receives Selected Heading from a Mode Control Panel / Flight Control Unit (MCP / FCU). Users of this data are cautioned that the Selected Heading value transmitted by the ADS-B Transmitting Subsystem does not necessarily reflect the true intention of the airplane during certain flight modes (e.g., during LNAV mode).
+NAV
+1. This data-item should only be transmitted if an ADS-B indication has been received that the mode bits have been "actively populated" by the avionics (1090 ES version 2 (as defined in I021/210) BDS 6,2, subtype 1, bit 47: "Status of MCP / FCU Mode Bits")
+GAO
+1. The value of this field is copied from the respective bits 33-40 of version 2 (as defined in I021/210) of 1090 ES BDS register 6,5 (Aircraft Operational Status)
+TNH
+1. Magnetic Heading is defined in I021/152.
+        </DataItemNote>
+    </DataItem>
+
+    <DataItem id="SP" rule="optional">
+        <DataItemName>Special Purpose</DataItemName>
+        <DataItemDefinition>Special information</DataItemDefinition>
+        <DataItemFormat desc="Repetitive data length item">
+            <Explicit>
+                <Fixed length="1">
+                    <Bits from="8" to="1">
+                        <BitsShortName>SPval</BitsShortName>
+                    </Bits>
+                </Fixed>
+            </Explicit>
+        </DataItemFormat>
+    </DataItem>
+
+    <UAP>
+        <UAPItem bit="0" frn="1" len="2">010</UAPItem>
+        <UAPItem bit="1" frn="2" len="1+">040</UAPItem>
+        <UAPItem bit="2" frn="3" len="2">161</UAPItem>
+        <UAPItem bit="3" frn="4" len="1">015</UAPItem>
+        <UAPItem bit="4" frn="5" len="3">071</UAPItem>
+        <UAPItem bit="5" frn="6" len="6">130</UAPItem>
+        <UAPItem bit="6" frn="7" len="8">131</UAPItem>
+        <UAPItem bit="7" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="8" frn="8" len="3">072</UAPItem>
+        <UAPItem bit="9" frn="9" len="2">150</UAPItem>
+        <UAPItem bit="10" frn="10" len="2">151</UAPItem>
+        <UAPItem bit="11" frn="11" len="3">080</UAPItem>
+        <UAPItem bit="12" frn="12" len="3">073</UAPItem>
+        <UAPItem bit="13" frn="13" len="4">074</UAPItem>
+        <UAPItem bit="14" frn="14" len="3">075</UAPItem>
+        <UAPItem bit="15" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="16" frn="15" len="4">076</UAPItem>
+        <UAPItem bit="17" frn="16" len="2">140</UAPItem>
+        <UAPItem bit="18" frn="17" len="1+">090</UAPItem>
+        <UAPItem bit="19" frn="18" len="1">210</UAPItem>
+        <UAPItem bit="20" frn="19" len="2">070</UAPItem>
+        <UAPItem bit="21" frn="20" len="2">230</UAPItem>
+        <UAPItem bit="22" frn="21" len="2">145</UAPItem>
+        <UAPItem bit="23" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="24" frn="22" len="2">152</UAPItem>
+        <UAPItem bit="25" frn="23" len="1">200</UAPItem>
+        <UAPItem bit="26" frn="24" len="2">155</UAPItem>
+        <UAPItem bit="27" frn="25" len="2">157</UAPItem>
+        <UAPItem bit="28" frn="26" len="4">160</UAPItem>
+        <UAPItem bit="29" frn="27" len="2">165</UAPItem>
+        <UAPItem bit="30" frn="28" len="3">077</UAPItem>
+        <UAPItem bit="31" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="32" frn="29" len="6">170</UAPItem>
+        <UAPItem bit="33" frn="30" len="1">020</UAPItem>
+        <UAPItem bit="34" frn="31" len="1+">220</UAPItem>
+        <UAPItem bit="35" frn="32" len="2">146</UAPItem>
+        <UAPItem bit="36" frn="33" len="2">148</UAPItem>
+        <UAPItem bit="37" frn="34" len="1+">110</UAPItem>
+        <UAPItem bit="38" frn="35" len="1">016</UAPItem>
+        <UAPItem bit="39" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="40" frn="36" len="1">008</UAPItem>
+        <UAPItem bit="41" frn="37" len="1+">271</UAPItem>
+        <UAPItem bit="42" frn="38" len="1">132</UAPItem>
+        <UAPItem bit="43" frn="39" len="1+N*8">250</UAPItem>
+        <UAPItem bit="44" frn="40" len="7">260</UAPItem>
+        <UAPItem bit="45" frn="41" len="1">400</UAPItem>
+        <UAPItem bit="46" frn="42" len="1+">295</UAPItem>
+        <UAPItem bit="47" frn="FX" len="-">-</UAPItem>
+        <UAPItem bit="48" frn="43" len="-">-</UAPItem>
+        <UAPItem bit="49" frn="44" len="-">-</UAPItem>
+        <UAPItem bit="50" frn="45" len="-">-</UAPItem>
+        <UAPItem bit="51" frn="46" len="-">-</UAPItem>
+        <UAPItem bit="52" frn="47" len="-">-</UAPItem>
+        <UAPItem bit="53" frn="48" len="1+">RE</UAPItem>
+        <UAPItem bit="54" frn="49" len="1+">SP</UAPItem>
+        <UAPItem bit="55" frn="FX" len="-">-</UAPItem>
+    </UAP>
+
+</Category>

--- a/asterix-specs-converter/cat011_cat-1.2.json
+++ b/asterix-specs-converter/cat011_cat-1.2.json
@@ -1453,6 +1453,7 @@
             "spare": false,
             "title": "System Track Update Ages",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -1947,6 +1948,7 @@
             "spare": false,
             "title": "Mode-S / ADS-B Related Data",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -2574,6 +2576,7 @@
             "spare": false,
             "title": "Flight Plan Related Data",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -3481,6 +3484,7 @@
             "spare": false,
             "title": "Estimated Accuracies",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -4344,6 +4348,7 @@
     "number": 11,
     "preamble": "Surveillance data exchange.\n",
     "title": "Transmission of A-SMGCS Data",
+    "type": "Basic",
     "uap": {
         "items": [
             "010",

--- a/asterix-specs-converter/cat011_cat-1.3.json
+++ b/asterix-specs-converter/cat011_cat-1.3.json
@@ -1453,6 +1453,7 @@
             "spare": false,
             "title": "System Track Update Ages",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -1947,6 +1948,7 @@
             "spare": false,
             "title": "Mode-S / ADS-B Related Data",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -2574,6 +2576,7 @@
             "spare": false,
             "title": "Flight Plan Related Data",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -3481,6 +3484,7 @@
             "spare": false,
             "title": "Estimated Accuracies",
             "variation": {
+                "fspec": null,
                 "items": [
                     {
                         "definition": null,
@@ -4344,6 +4348,7 @@
     "number": 11,
     "preamble": "Surveillance data exchange.\n",
     "title": "Transmission of A-SMGCS Data",
+    "type": "Basic",
     "uap": {
         "items": [
             "010",

--- a/asterix-specs-converter/cat021_cat-2.4.json
+++ b/asterix-specs-converter/cat021_cat-2.4.json
@@ -1,0 +1,4801 @@
+{
+    "catalogue": [
+        {
+            "definition": "Identification of the operational services available in the aircraft\nwhile airborne.\n",
+            "description": null,
+            "name": "008",
+            "remark": "Note:\n    - Additional Aircraft Status Information is available in the Reserved\n      Expansion Field of Category 021.\n",
+            "spare": false,
+            "title": "Aircraft Operational Status",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "TCAS Resolution Advisory active",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "TCAS II or ACAS RA not active"
+                                        ],
+                                        [
+                                            1,
+                                            "TCAS RA active"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Target Trajectory Change Report Capability",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "no capability for Trajectory Change Reports"
+                                        ],
+                                        [
+                                            1,
+                                            "support for TC+0 reports only"
+                                        ],
+                                        [
+                                            2,
+                                            "support for multiple TC reports"
+                                        ],
+                                        [
+                                            3,
+                                            "reserved"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Target State Report Capability",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "no capability to support Target State Reports"
+                                        ],
+                                        [
+                                            1,
+                                            "capable of supporting target State Reports"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ARV",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Air-Referenced Velocity Report Capability",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "no capability to generate ARV-reports"
+                                        ],
+                                        [
+                                            1,
+                                            "capable of generate ARV-reports"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "CDTI_A",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Cockpit Display of Traffic Information airborne",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "CDTI not operational"
+                                        ],
+                                        [
+                                            1,
+                                            "CDTI operational"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NOTTCAS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "TCAS System Status",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "TCAS operational"
+                                        ],
+                                        [
+                                            1,
+                                            "TCAS not operational"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Single Antenna",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Antenna Diversity"
+                                        ],
+                                        [
+                                            1,
+                                            "Single Antenna only"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Identification of the ADS-B station providing information.\n",
+            "description": null,
+            "name": "010",
+            "remark": "Note:\n    - The up-to-date list of SACs is published on the EUROCONTROL\n      ASTERIX Web Site\n      (http://www.eurocontrol.int/services/system-area-code-list).\n",
+            "spare": false,
+            "title": "Data Source Identification",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SAC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "System Area Code",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SIC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "System Identification code",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Identification of the service provided to one or more users.\n",
+            "description": null,
+            "name": "015",
+            "remark": "Notes:\n\n    1. The service identification is allocated by the system.\n    2. The service identification is also available in item I023/015 [Ref. 3].\n",
+            "spare": false,
+            "title": "Service Identification",
+            "variation": {
+                "content": {
+                    "type": "Unspecified"
+                },
+                "size": 8,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Identification of services offered by a ground station (identified by a SIC code).\n",
+            "description": null,
+            "name": "016",
+            "remark": "Notes:\n\n    1. This item contains the same information as item I023/101 in\n       ASTERIX category 023 [Ref. 3]. Since not all service users\n       receive category 023 data, this information has to be conveyed\n       in category 021 as well.\n    2. If this item is due to be sent according to the encoding rule\n       above, it shall be sent with the next target report\n",
+            "spare": false,
+            "title": "Service Management",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 1,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 8,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Characteristics of the originating ADS-B unit.\n",
+            "description": null,
+            "name": "020",
+            "remark": null,
+            "spare": false,
+            "title": "Emitter Category",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "type": "Table",
+                        "values": [
+                            [
+                                0,
+                                "No ADS-B Emitter Category Information"
+                            ],
+                            [
+                                1,
+                                "light aircraft <= 15500 lbs"
+                            ],
+                            [
+                                2,
+                                "15500 lbs < small aircraft <75000 lbs"
+                            ],
+                            [
+                                3,
+                                "75000 lbs < medium a/c < 300000 lbs"
+                            ],
+                            [
+                                4,
+                                "High Vortex Large"
+                            ],
+                            [
+                                5,
+                                "300000 lbs <= heavy aircraft"
+                            ],
+                            [
+                                6,
+                                "highly manoeuvrable (5g acceleration capability) and high speed (>400 knots cruise)"
+                            ],
+                            [
+                                7,
+                                "reserved"
+                            ],
+                            [
+                                8,
+                                "reserved"
+                            ],
+                            [
+                                9,
+                                "reserved"
+                            ],
+                            [
+                                10,
+                                "rotocraft"
+                            ],
+                            [
+                                11,
+                                "glider / sailplane"
+                            ],
+                            [
+                                12,
+                                "lighter-than-air"
+                            ],
+                            [
+                                13,
+                                "unmanned aerial vehicle"
+                            ],
+                            [
+                                14,
+                                "space / transatmospheric vehicle"
+                            ],
+                            [
+                                15,
+                                "ultralight / handglider / paraglider"
+                            ],
+                            [
+                                16,
+                                "parachutist / skydiver"
+                            ],
+                            [
+                                17,
+                                "reserved"
+                            ],
+                            [
+                                18,
+                                "reserved"
+                            ],
+                            [
+                                19,
+                                "reserved"
+                            ],
+                            [
+                                20,
+                                "surface emergency vehicle"
+                            ],
+                            [
+                                21,
+                                "surface service vehicle"
+                            ],
+                            [
+                                22,
+                                "fixed ground or tethered obstruction"
+                            ],
+                            [
+                                23,
+                                "cluster obstacle"
+                            ],
+                            [
+                                24,
+                                "line obstacle"
+                            ]
+                        ]
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 8,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Type and characteristics of the data as transmitted by a system.\n",
+            "description": null,
+            "name": "040",
+            "remark": "Notes:\n\n    1. Bit 3 indicates that the position reported by the target is\n       within a credible range from the ground station. The range\n       check is followed by the CPR validation to ensure that global\n       and local position decoding both indicate valid position\n       information. Bit 3=1 indicates that the range check was done,\n       but the CPR validation is not yet completed.\n       Once CPR validation is completed, Bit 3 will be reset to 0.\n    2. The second extension signals the reasons for which the report has\n       been indicated as suspect (indication Confidence Level (CL) in the\n       first extension).\n    3. Bit 2 indicates that the Range Check failed, i.e. the target is\n       reported outside the credible range for the Ground Station. For\n       operational users such a target will be suppressed. In services\n       used for monitoring the Ground Station, the target will be\n       transmitted with bit 2 indicating the fault condition.\n    4. Bit 6, if set to 1, indicates that the position reported by the\n       target was validated by an independent means and a discrepancy\n       was detected. If no independent position check is implemented,\n       the default value “0” is to be used.\n    5. Bit 5 represents the setting of the GO/NOGO-bit as defined in\n       item I023/100 of category 023 [Ref. 3].\n    6. Bit 7, if set to 1, indicates that a lookup in a Black-list/White-list\n       failed, indicating that the target may be suspect\n",
+            "spare": false,
+            "title": "Target Report Descriptor",
+            "variation": {
+                "extents": 8,
+                "first": 8,
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ATP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Address Type",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "24-Bit ICAO address"
+                                        ],
+                                        [
+                                            1,
+                                            "Duplicate address"
+                                        ],
+                                        [
+                                            2,
+                                            "Surface vehicle address"
+                                        ],
+                                        [
+                                            3,
+                                            "Anonymous address"
+                                        ],
+                                        [
+                                            4,
+                                            "Reserved for future use"
+                                        ],
+                                        [
+                                            5,
+                                            "Reserved for future use"
+                                        ],
+                                        [
+                                            6,
+                                            "Reserved for future use"
+                                        ],
+                                        [
+                                            7,
+                                            "Reserved for future use"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ARC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Altitude Reporting Capability",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "25 ft"
+                                        ],
+                                        [
+                                            1,
+                                            "100 ft"
+                                        ],
+                                        [
+                                            2,
+                                            "Unknown"
+                                        ],
+                                        [
+                                            3,
+                                            "Invalid"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Check",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Default"
+                                        ],
+                                        [
+                                            1,
+                                            "Range Check passed, CPR Validation pending"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RAB",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Report Type",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Report from target transponder"
+                                        ],
+                                        [
+                                            1,
+                                            "Report from field monitor (fixed transponder)"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "DCR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Differential Correction",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No differential correction (ADS-B)"
+                                        ],
+                                        [
+                                            1,
+                                            "Differential correction (ADS-B)"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "GBS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Ground Bit Setting",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Ground Bit not set"
+                                        ],
+                                        [
+                                            1,
+                                            "Ground Bit set"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SIM",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Simulated Target",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Actual target report"
+                                        ],
+                                        [
+                                            1,
+                                            "Simulated target report"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TST",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Test Target",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Default"
+                                        ],
+                                        [
+                                            1,
+                                            "Test Target"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SAA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Selected Altitude Available",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Equipment capable to provide Selected Altitude"
+                                        ],
+                                        [
+                                            1,
+                                            "Equipment not capable to provide Selected Altitude"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "CL",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Confidence Level",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Report valid"
+                                        ],
+                                        [
+                                            1,
+                                            "Report suspect"
+                                        ],
+                                        [
+                                            2,
+                                            "No information"
+                                        ],
+                                        [
+                                            3,
+                                            "Reserved for future use"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "length": 1,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LLC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "List Lookup Check",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "default"
+                                        ],
+                                        [
+                                            1,
+                                            "List Lookup failed (see note)"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "IPC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Independent Position Check",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "default (see note)"
+                                        ],
+                                        [
+                                            1,
+                                            "Independent Position Check failed"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NOGO",
+                        "remark": null,
+                        "spare": false,
+                        "title": "No-go Bit Status",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "NOGO-bit not set"
+                                        ],
+                                        [
+                                            1,
+                                            "NOGO-bit set"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "CPR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Compact Position Reporting",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "CPR Validation correct"
+                                        ],
+                                        [
+                                            1,
+                                            "CPR Validation failed"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LDPJ",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Local Decoding Position Jump",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "LDPJ not detected"
+                                        ],
+                                        [
+                                            1,
+                                            "LDPJ detected"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RCF",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Check",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "default"
+                                        ],
+                                        [
+                                            1,
+                                            "Range Check failed"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Extended"
+            }
+        },
+        {
+            "definition": "Mode-3/A code converted into octal representation.\n",
+            "description": null,
+            "name": "070",
+            "remark": null,
+            "spare": false,
+            "title": "Mode 3/A Code in Octal Representation",
+            "variation": {
+                "items": [
+                    {
+                        "length": 4,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ABCD",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Mode-3/A reply in octal representation",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 12,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Time of applicability of the reported position, in the form of elapsed\ntime since last midnight, expressed as UTC.\n",
+            "description": null,
+            "name": "071",
+            "remark": "Notes:\n\n    1. The time of applicability value is reset to zero at every midnight.\n    2. The time of applicability indicates the exact time at which the\n       position transmitted in the target report is valid.\n",
+            "spare": false,
+            "title": "Time of Applicability for Position",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 7,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Time of applicability (measurement) of the reported velocity, in the\nform of elapsed time since last midnight, expressed as UTC.\n",
+            "description": null,
+            "name": "072",
+            "remark": "Notes:\n\n    1. The time of the applicability value is reset to zero at every midnight.\n    2. The time of applicability indicates the exact time at which the\n       velocity information transmitted in the target report is valid.\n    3. This item will not be available in some ADS-B technologies.\n",
+            "spare": false,
+            "title": "Time of Applicability for Velocity",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 7,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Time of reception of the latest position squitter in the Ground Station,\nin the form of elapsed time since last midnight, expressed as UTC.\n",
+            "description": null,
+            "name": "073",
+            "remark": "Note:\n    - The time of message reception value is reset to zero at every midnight.\n",
+            "spare": false,
+            "title": "Time of Message Reception for Position",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 7,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Time at which the latest ADS-B position information was received by\nthe ground station, expressed as fraction of the second of the UTC Time.\n",
+            "description": null,
+            "name": "074",
+            "remark": null,
+            "spare": false,
+            "title": "Time of Message Reception of Position-High Precision",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "FSI",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Full Second Indication",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            3,
+                                            "Reserved"
+                                        ],
+                                        [
+                                            2,
+                                            "TOMRp whole seconds = (I021/073) Whole seconds – 1"
+                                        ],
+                                        [
+                                            1,
+                                            "TOMRp whole seconds = (I021/073) Whole seconds + 1"
+                                        ],
+                                        [
+                                            0,
+                                            "TOMRp whole seconds = (I021/073) Whole seconds"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TOMRP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Fractional part of the time of message reception for position in the ground station.",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 30,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 30,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Time of reception of the latest velocity squitter in the Ground Station,\nin the form of elapsed time since last midnight, expressed as UTC.\n",
+            "description": null,
+            "name": "075",
+            "remark": "Note:\n    - The time of message reception value is reset to zero at every midnight.\n",
+            "spare": false,
+            "title": "Time of Message Reception for Velocity",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 7,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Time at which the latest ADS-B velocity information was received by\nthe ground station, expressed as fraction of the second of the UTC Time.\n",
+            "description": null,
+            "name": "076",
+            "remark": null,
+            "spare": false,
+            "title": "Time of Message Reception of Velocity-High Precision",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "FSI",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Full Second Indication",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            3,
+                                            "Reserved"
+                                        ],
+                                        [
+                                            2,
+                                            "TOMRv whole seconds = (I021/075) Whole seconds - 1"
+                                        ],
+                                        [
+                                            1,
+                                            "TOMRv whole seconds = (I021/075) Whole seconds + 1"
+                                        ],
+                                        [
+                                            0,
+                                            "TOMRv whole seconds = (I021/075) Whole seconds"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TOMRP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Fractional part of the time of message reception for position in the ground station.",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 30,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 30,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Time of the transmission of the ASTERIX category 021 report in the\nform of elapsed time since last midnight, expressed as UTC.\n",
+            "description": null,
+            "name": "077",
+            "remark": "Note:\n    - The time of ASTERIX report transmission value is reset to zero at\n      every midnight.\n",
+            "spare": false,
+            "title": "Time of ASTERIX Report Transmission",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 7,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "s"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Target address (emitter identifier) assigned uniquely to each target.\n",
+            "description": null,
+            "name": "080",
+            "remark": null,
+            "spare": false,
+            "title": "Target Address",
+            "variation": {
+                "content": {
+                    "type": "Unspecified"
+                },
+                "size": 24,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "ADS-B quality indicators transmitted by a/c according to MOPS version.\n",
+            "description": null,
+            "name": "090",
+            "remark": "Notes:\n\n    1. Apart from the “PIC” item, all items are defined as per the\n       respective link technology protocol version (“MOPS version”,\n       see I021/210).\n    2. The primary subfield is kept for backwards compatibility reasons.\n       Version 2 NIC-values shall be mapped accordingly. This is required\n       to ensure that downstream systems, which are not capable of\n       interpreting extensions 2 and 3 (because they use an ASTERIX\n       edition earlier than 2.0) still get the required information\n    3. “Version 1” or “Version 2” refers to the MOPS version as defined\n       in data item I021/210, bits 6/4\n    4. “Version 2” refers to the MOPS version as defined in data item\n       I021/210, bits 6/4\n    5. PIC=0 is defined for completeness only. In this case the third\n       extension shall not be generated.\n    6. For ED102A/DO260B PIC values of 7 and 9, the NIC supplements\n       for airborne messages (NIC supplements A/B) and surface messages\n       (NIC supplements A/C) are listed.\n       For ED102A/DO260B PIC=8, the NIC supplements A/B for airborne\n       messages are listed.\n       For DO260A PIC values of 7 and 8, the NIC supplement for airborne\n       messages is shown in brackets.\n       The aircraft air-ground status, and hence message type (airborne\n       or surface), is derived from the GBS-bit in I021/040, 1 st extension.\n",
+            "spare": false,
+            "title": "Quality Indicators",
+            "variation": {
+                "extents": 8,
+                "first": 8,
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NUCR_NACV",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Navigation Uncertainty Category for velocity NUCr or the Navigation Accuracy Category for Velocity NACv",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NUCP_NIC",
+                        "remark": "Notes:\n    1. Apart from the “PIC” item, all items are defined as per the\n       respective link technology protocol version (“MOPS version”,\n       see I021/210).\n    2. The primary subfield is kept for backwards compatibility reasons.\n       Version 2 NIC-values shall be mapped accordingly. This is required\n       to ensure that downstream systems, which are not capable of\n       interpreting extensions 2 and 3 (because they use an ASTERIX\n",
+                        "spare": false,
+                        "title": "Navigation Uncertainty Category for Position NUCp or Navigation Integrity Category NIC.",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 4,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NICBARO",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Navigation Integrity Category for Barometric Altitude",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SIL",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Surveillance (version 1) or Source (version 2) Integrity Level",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "NACP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Navigation Accuracy Category for Position",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 4,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "length": 2,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SILS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "SIL-Supplement",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "measured per flight-hour"
+                                        ],
+                                        [
+                                            1,
+                                            "measured per sample"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SDA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Horizontal Position System Design Assurance Level (as defined in version 2)",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "GVA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Geometric Altitude Accuracy",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "PIC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Position Integrity Category",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 4,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "length": 3,
+                        "spare": true
+                    }
+                ],
+                "type": "Extended"
+            }
+        },
+        {
+            "definition": "Reports indicating the 4D intended trajectory of the aircraft.\n",
+            "description": null,
+            "name": "110",
+            "remark": "Notes:\n\n    1. NC is set to one when the aircraft will not fly the path described\n       by the TCP data.\n    2. TCP numbers start from zero.\n    3. LT = Lateral Type\n    4. VT = Vertical Type\n    5. TOV gives the estimated time before reaching the point. It is\n       defined as the absolute time from midnight.\n    6. TOV is meaningful only if TOA is set to 1.\n",
+            "spare": false,
+            "title": "Trajectory Intent",
+            "variation": {
+                "fspec": null,
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TIS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Trajectory Intent Status",
+                        "variation": {
+                            "extents": 8,
+                            "first": 8,
+                            "items": [
+                                {
+                                    "definition": null,
+                                    "description": null,
+                                    "name": "NAV",
+                                    "remark": null,
+                                    "spare": false,
+                                    "title": "",
+                                    "variation": {
+                                        "content": {
+                                            "rule": {
+                                                "type": "Table",
+                                                "values": [
+                                                    [
+                                                        0,
+                                                        "Trajectory Intent Data is available for this aircraft"
+                                                    ],
+                                                    [
+                                                        1,
+                                                        "Trajectory Intent Data is not available for this aircraft"
+                                                    ]
+                                                ]
+                                            },
+                                            "type": "ContextFree"
+                                        },
+                                        "size": 1,
+                                        "type": "Element"
+                                    }
+                                },
+                                {
+                                    "definition": null,
+                                    "description": null,
+                                    "name": "NVB",
+                                    "remark": null,
+                                    "spare": false,
+                                    "title": "",
+                                    "variation": {
+                                        "content": {
+                                            "rule": {
+                                                "type": "Table",
+                                                "values": [
+                                                    [
+                                                        0,
+                                                        "Trajectory Intent Data is valid"
+                                                    ],
+                                                    [
+                                                        1,
+                                                        "Trajectory Intent Data is not valid"
+                                                    ]
+                                                ]
+                                            },
+                                            "type": "ContextFree"
+                                        },
+                                        "size": 1,
+                                        "type": "Element"
+                                    }
+                                },
+                                {
+                                    "length": 5,
+                                    "spare": true
+                                }
+                            ],
+                            "type": "Extended"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TID",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Trajectory Intent Data",
+                        "variation": {
+                            "rep": 8,
+                            "type": "Repetitive",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "TCA",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "TCP number available"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "TCP number not available"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "NC",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "TCP compliance"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "TCP non-compliance"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": "Trajectory Change Point number\n",
+                                        "name": "TCPNumber",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "type": "Unspecified"
+                                            },
+                                            "size": 6,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "Altitude",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Altitude in two's complement form",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "constraints": [
+                                                        {
+                                                            "type": ">=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": -1500
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "<=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": 150000
+                                                            }
+                                                        }
+                                                    ],
+                                                    "fractionalBits": 0,
+                                                    "scaling": {
+                                                        "type": "Integer",
+                                                        "value": 10
+                                                    },
+                                                    "signed": true,
+                                                    "type": "Quantity",
+                                                    "unit": "ft"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 16,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "Latitude",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "In WGS.84 in two's complement.",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "constraints": [
+                                                        {
+                                                            "type": ">=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": -90
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "<=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": 90
+                                                            }
+                                                        }
+                                                    ],
+                                                    "fractionalBits": 23,
+                                                    "scaling": {
+                                                        "type": "Integer",
+                                                        "value": 180
+                                                    },
+                                                    "signed": true,
+                                                    "type": "Quantity",
+                                                    "unit": "deg"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 24,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "Longitude",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "In WGS.84 in two's complement.",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "constraints": [
+                                                        {
+                                                            "type": ">=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": -180
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "<",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": 180
+                                                            }
+                                                        }
+                                                    ],
+                                                    "fractionalBits": 23,
+                                                    "scaling": {
+                                                        "type": "Integer",
+                                                        "value": 180
+                                                    },
+                                                    "signed": true,
+                                                    "type": "Quantity",
+                                                    "unit": "deg"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 24,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "PT",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Point Type",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Unknown"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Fly by waypoint (LT)"
+                                                        ],
+                                                        [
+                                                            2,
+                                                            "Fly over waypoint (LT)"
+                                                        ],
+                                                        [
+                                                            3,
+                                                            "Hold pattern (LT)"
+                                                        ],
+                                                        [
+                                                            4,
+                                                            "Procedure hold (LT)"
+                                                        ],
+                                                        [
+                                                            5,
+                                                            "Procedure turn (LT)"
+                                                        ],
+                                                        [
+                                                            6,
+                                                            "RF leg (LT)"
+                                                        ],
+                                                        [
+                                                            7,
+                                                            "Top of climb (VT)"
+                                                        ],
+                                                        [
+                                                            8,
+                                                            "Top of descent (VT)"
+                                                        ],
+                                                        [
+                                                            9,
+                                                            "Start of level (VT)"
+                                                        ],
+                                                        [
+                                                            10,
+                                                            "Cross-over altitude (VT)"
+                                                        ],
+                                                        [
+                                                            11,
+                                                            "Transition altitude (VT)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 4,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "TD",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "N/A"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Turn right"
+                                                        ],
+                                                        [
+                                                            2,
+                                                            "Turn left"
+                                                        ],
+                                                        [
+                                                            3,
+                                                            "No turn"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 2,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": "Turn Radius Availability\n",
+                                        "name": "TRA",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "TTR not available"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "TTR available"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "TOA",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "TOV available"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "TOV not available"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "TOV",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Time Over Point",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "constraints": [],
+                                                    "fractionalBits": 0,
+                                                    "scaling": {
+                                                        "type": "Integer",
+                                                        "value": 1
+                                                    },
+                                                    "signed": false,
+                                                    "type": "Quantity",
+                                                    "unit": "s"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 24,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "TTR",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "TCP Turn radius",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "constraints": [
+                                                        {
+                                                            "type": ">=",
+                                                            "value": {
+                                                                "type": "Integer",
+                                                                "value": 0
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "<=",
+                                                            "value": {
+                                                                "type": "Real",
+                                                                "value": 655.35
+                                                            }
+                                                        }
+                                                    ],
+                                                    "fractionalBits": 0,
+                                                    "scaling": {
+                                                        "type": "Real",
+                                                        "value": 1.0e-2
+                                                    },
+                                                    "signed": false,
+                                                    "type": "Quantity",
+                                                    "unit": "Nm"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 16,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        }
+                    }
+                ],
+                "type": "Compound"
+            }
+        },
+        {
+            "definition": "Position in WGS-84 Co-ordinates.\n",
+            "description": null,
+            "name": "130",
+            "remark": "Notes:\n\n    - Positive longitude indicates East. Positive latitude indicates North.\n",
+            "spare": false,
+            "title": "Position in WGS-84 Co-ordinates",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LAT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Latitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -90
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 90
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 23,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 180
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 24,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LON",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Longitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -180
+                                            }
+                                        },
+                                        {
+                                            "type": "<",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 180
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 23,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 180
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 24,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Position in WGS-84 Co-ordinates in high resolution.\n",
+            "description": null,
+            "name": "131",
+            "remark": "Notes:\n\n    - Positive longitude indicates East. Positive latitude indicates North.\n",
+            "spare": false,
+            "title": "High-Resolution Position in WGS-84 Co-ordinates",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LAT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Latitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -90
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 90
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 30,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 180
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 32,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LON",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Longitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -180
+                                            }
+                                        },
+                                        {
+                                            "type": "<",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 180
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 30,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 180
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 32,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Amplitude, in dBm, of ADS-B messages received by the ground station,\ncoded in two’s complement.\n",
+            "description": null,
+            "name": "132",
+            "remark": "Note:\n    - The value gives the amplitude of the latest received squitter.\n",
+            "spare": false,
+            "title": "Message Amplitude",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 0,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": true,
+                        "type": "Quantity",
+                        "unit": "dBm"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 8,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Minimum height from a plane tangent to the earth’s ellipsoid, defined\nby WGS-84, in two’s complement form.\n",
+            "description": null,
+            "name": "140",
+            "remark": "Note:\n    1. LSB is required to be less than 10 ft by ICAO.\n    2. A value of ‘0111111111111111’ indicates that the aircraft transmits\n       a “greater than” indication.\n",
+            "spare": false,
+            "title": "Geometric Height",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [
+                            {
+                                "type": ">=",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": -1500
+                                }
+                            },
+                            {
+                                "type": "<",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": 150000
+                                }
+                            }
+                        ],
+                        "fractionalBits": 0,
+                        "scaling": {
+                            "type": "Real",
+                            "value": 6.25
+                        },
+                        "signed": true,
+                        "type": "Quantity",
+                        "unit": "ft"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 16,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Flight Level from barometric measurements,not QNH corrected, in two’s\ncomplement form.\n",
+            "description": null,
+            "name": "145",
+            "remark": null,
+            "spare": false,
+            "title": "Flight Level",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [
+                            {
+                                "type": ">=",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": -15
+                                }
+                            },
+                            {
+                                "type": "<",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": 1500
+                                }
+                            }
+                        ],
+                        "fractionalBits": 2,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 1
+                        },
+                        "signed": true,
+                        "type": "Quantity",
+                        "unit": "FL"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 16,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "The Selected Altitude as provided by the avionics and corresponding\neither to the MCP/FCU Selected Altitude (the ATC cleared altitude\nentered by the flight crew into the avionics) or to the FMS Selected Altitude.\n",
+            "description": null,
+            "name": "146",
+            "remark": "Notes:\n\n    1. The Selected Altitude provided in this field is not necessarily\n       the “Target Altitude” as defined by ICAO.\n    2. The value of “Source” (bits 15/14) indicating “unknown” or “Aircraft\n       Altitude” is kept for backward compatibility as these indications are\n       not provided by “version 2” systems as defined by data item I021/210,\n       bits 6/4.\n    3. Vertical mode indications supporting the determination of the\n       nature of the Selected Altitude are provided in the Reserved\n       Expansion Field in the subfield NAV.\n",
+            "spare": false,
+            "title": "Selected Altitude",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SAS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Source Availability",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No source information provided"
+                                        ],
+                                        [
+                                            1,
+                                            "Source Information provided"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "S",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Source",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Unknown"
+                                        ],
+                                        [
+                                            1,
+                                            "Aircraft Altitude (Holding Altitude)"
+                                        ],
+                                        [
+                                            2,
+                                            "MCP/FCU Selected Altitude"
+                                        ],
+                                        [
+                                            3,
+                                            "FMS Selected Altitude"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ALT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Altitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -1300
+                                            }
+                                        },
+                                        {
+                                            "type": "<",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 100000
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 25
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "ft"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 13,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "The vertical intent value that corresponds with the ATC cleared altitude,\nas derived from the Altitude Control Panel (MCP/FCU).\n",
+            "description": null,
+            "name": "148",
+            "remark": "Notes:\n\n    - This item is kept for backward compatibility but shall not be used\n      for “version 2” ADS-B systems (as defined by data item I021/210,\n      bits 6/4) for which item 146 will be used to forward the MCP/FCU\n      or the FMS selected altitude information. For “version 2” ADS-B\n      systems, the vertical mode indications will be provided through\n      the Reserved Expansion Field in the subfield NAV .\n",
+            "spare": false,
+            "title": "Final State Selected Altitude",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "MV",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Manage Vertical Mode",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Not active or unknown"
+                                        ],
+                                        [
+                                            1,
+                                            "Active"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "AH",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Altitude Hold Mode",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Not active or unknown"
+                                        ],
+                                        [
+                                            1,
+                                            "Active"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "AM",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Approach Mode",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Not active or unknown"
+                                        ],
+                                        [
+                                            1,
+                                            "Active"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ALT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Altitude",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -1300
+                                            }
+                                        },
+                                        {
+                                            "type": "<",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 100000
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 25
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "ft"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 13,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Calculated Air Speed (Element of Air Vector).\n",
+            "description": null,
+            "name": "150",
+            "remark": null,
+            "spare": false,
+            "title": "Air Speed",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "IM",
+                        "remark": null,
+                        "spare": false,
+                        "title": "",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Air Speed = IAS, LSB (Bit-1) = 2 -14 NM/s"
+                                        ],
+                                        [
+                                            1,
+                                            "Air Speed = Mach, LSB (Bit-1) = 0.001"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "AS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Air Speed (IAS or Mach)",
+                        "variation": {
+                            "content": {
+                                "name": [
+                                    "150",
+                                    "IM"
+                                ],
+                                "rules": [
+                                    [
+                                        0,
+                                        {
+                                            "constraints": [],
+                                            "fractionalBits": 14,
+                                            "scaling": {
+                                                "type": "Integer",
+                                                "value": 1
+                                            },
+                                            "signed": false,
+                                            "type": "Quantity",
+                                            "unit": "NM/s"
+                                        }
+                                    ],
+                                    [
+                                        1,
+                                        {
+                                            "constraints": [],
+                                            "fractionalBits": 0,
+                                            "scaling": {
+                                                "type": "Real",
+                                                "value": 1.0e-3
+                                            },
+                                            "signed": false,
+                                            "type": "Quantity",
+                                            "unit": "mach"
+                                        }
+                                    ]
+                                ],
+                                "type": "Dependent"
+                            },
+                            "size": 15,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "True Air Speed.\n",
+            "description": null,
+            "name": "151",
+            "remark": "Notes:\n\n    - The RE-Bit, if set, indicates that the value to be transmitted is\n      beyond the range defined for this specific data item and the\n      applied technology. In this case the True Air Speed contains the\n      maximum value that can be downloaded from the aircraft avionics\n      and the RE-bit indicates that the actual value is greater than the\n      value contained in the field.\n",
+            "spare": false,
+            "title": "True Airspeed",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RE",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Exceeded Indicator",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Value in defined range"
+                                        ],
+                                        [
+                                            1,
+                                            "Value exceeds defined range"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TAS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "True Air Speed",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "kt"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 15,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Magnetic Heading (Element of Air Vector).\n",
+            "description": null,
+            "name": "152",
+            "remark": "Notes:\n\n    - True North Heading is defined in the Reserved Expansion Field in\n      the subfield TNH.\n",
+            "spare": false,
+            "title": "Magnetic Heading",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [],
+                        "fractionalBits": 16,
+                        "scaling": {
+                            "type": "Integer",
+                            "value": 360
+                        },
+                        "signed": false,
+                        "type": "Quantity",
+                        "unit": "deg"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 16,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Barometric Vertical Rate, in two’s complement form.\n",
+            "description": null,
+            "name": "155",
+            "remark": "Notes:\n\n    - The RE-Bit, if set, indicates that the value to be transmitted is\n      beyond the range defined for this specific data item and the applied\n      technology. In this case the Barometric Vertical Rate contains the\n      maximum value that can be downloaded from the aircraft avionics and\n      the RE-bit indicates that the actual value is greater than the value\n      contained in the field.\n",
+            "spare": false,
+            "title": "Barometric Vertical Rate",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RE",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Exceeded Indicator",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Value in defined range"
+                                        ],
+                                        [
+                                            1,
+                                            "Value exceeds defined range"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "BVR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Barometric Vertical Rate",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 6.25
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "feet/min"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 15,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Geometric Vertical Rate, in two’s complement form, with reference to WGS-84.\n",
+            "description": null,
+            "name": "157",
+            "remark": "Notes:\n\n    - The RE-Bit, if set, indicates that the value to be transmitted is\n      beyond the range defined for this specific data item and the applied\n      technology. In this case the Geometric Vertical Rate contains the\n      maximum value that can be downloaded from the aircraft avionics and\n      the RE-bit indicates that the actual value is greater than the value\n      contained in the field.\n",
+            "spare": false,
+            "title": "Geometric Vertical Rate",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RE",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Exceeded Indicator",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Value in defined range"
+                                        ],
+                                        [
+                                            1,
+                                            "Value exceeds defined range"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "GVR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Geometric Vertical Rate",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 6.25
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "feet/min"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 15,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Ground Speed and Track Angle elements of Airborne Ground Vector.\n",
+            "description": null,
+            "name": "160",
+            "remark": "Notes:\n\n    1. The RE-Bit, if set, indicates that the value to be transmitted is\n       beyond the range defined for this specific data item and the applied\n       technology. In this case the Ground Speed contains the maximum value\n       that can be downloaded from the aircraft avionics and the RE-bit\n       indicates that the actual value is greater than the value contained\n       in the field.\n    2. The Surface Ground Vector format is defined in the Reserved Expansion\n       Field in the subfield SGV.\n",
+            "spare": false,
+            "title": "Airborne Ground Vector",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RE",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Range Exceeded Indicator",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Value in defined range"
+                                        ],
+                                        [
+                                            1,
+                                            "Value exceeds defined range"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "GS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Ground Speed referenced to WGS-84",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 0
+                                            }
+                                        },
+                                        {
+                                            "type": "<",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 2
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 14,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "NM/s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 15,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Track Angle clockwise reference to True North",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [],
+                                    "fractionalBits": 16,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 360
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 16,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "An integer value representing a unique reference to a track record\nwithin a particular track file.\n",
+            "description": null,
+            "name": "161",
+            "remark": null,
+            "spare": false,
+            "title": "Track Number",
+            "variation": {
+                "items": [
+                    {
+                        "length": 4,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TRNUM",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Track number",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 12,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Rate of Turn, in two’s complement form.\n",
+            "description": null,
+            "name": "165",
+            "remark": "Notes:\n\n    1. A positive value represents a right turn, whereas a negative value\n       represents a left turn.\n    2. Maximum value means Maximum value or above.\n    3. This item will not be transmitted for the technology 1090 MHz\n       Extended Squitter.\n",
+            "spare": false,
+            "title": "Track Angle Rate",
+            "variation": {
+                "items": [
+                    {
+                        "length": 6,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TAR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Track Angle Rate",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -16
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 16
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 5,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "deg/s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 10,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Target (aircraft or vehicle) identification in 8 characters, as reported\nby the target.\n",
+            "description": null,
+            "name": "170",
+            "remark": null,
+            "spare": false,
+            "title": "Target Identification",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "type": "String",
+                        "variation": "StringICAO"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 48,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Status of the target\n",
+            "description": null,
+            "name": "200",
+            "remark": "Notes:\n\n    - Bit-8 (ICF), when set to “1” indicates that new information is\n      available in the Mode S GICB registers 40, 41 or 42.\n",
+            "spare": false,
+            "title": "Target Status",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ICF",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Intent Change Flag (see Note)",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No intent change active"
+                                        ],
+                                        [
+                                            1,
+                                            "Intent change flag raised"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LNAV",
+                        "remark": null,
+                        "spare": false,
+                        "title": "LNAV Mode",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "LNAV Mode engaged"
+                                        ],
+                                        [
+                                            1,
+                                            "LNAV Mode not engaged"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ME",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Military emergency",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No military emergency"
+                                        ],
+                                        [
+                                            1,
+                                            "Military emergency"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "PS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Priority Status",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No emergency / not reported"
+                                        ],
+                                        [
+                                            1,
+                                            "General emergency"
+                                        ],
+                                        [
+                                            2,
+                                            "Lifeguard / medical emergency"
+                                        ],
+                                        [
+                                            3,
+                                            "Minimum fuel"
+                                        ],
+                                        [
+                                            4,
+                                            "No communications"
+                                        ],
+                                        [
+                                            5,
+                                            "Unlawful interference"
+                                        ],
+                                        [
+                                            6,
+                                            "“Downed” Aircraft"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "SS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Surveillance Status",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "No condition reported"
+                                        ],
+                                        [
+                                            1,
+                                            "Permanent Alert (Emergency condition)"
+                                        ],
+                                        [
+                                            2,
+                                            "Temporary Alert (change in Mode 3/A Code other than emergency)"
+                                        ],
+                                        [
+                                            3,
+                                            "SPI set"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Identification of the MOPS version used by a/c to supply ADS-B information.\n",
+            "description": null,
+            "name": "210",
+            "remark": "Notes:\n\n    - VN sub-field shall contain a value describing the MOPS used by each aircraft.\n      The versions of other link technologies are assumed to be in line\n      with the 1090 ES MOPS versions and the corresponding MASPS versions.\n\n    - Bit 7 (VNS) when set to 1 indicates that the aircraft transmits a\n      MOPS Version indication that is not supported by the Ground Station.\n      However, since MOPS versions are supposed to be backwards compatible,\n      the GS has attempted to interpret the message and achieved a credible\n      result. The fact that the MOPS version received is not supported by\n      the GS is submitted as additional information to subsequent processing\n      systems.\n",
+            "spare": false,
+            "title": "MOPS Version",
+            "variation": {
+                "items": [
+                    {
+                        "length": 1,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "VNS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Version Not Supported",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "The MOPS Version is supported by the GS"
+                                        ],
+                                        [
+                                            1,
+                                            "The MOPS Version is not supported by the GS"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "VN",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Version Number",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "ED102/DO-260 [Ref. 8]"
+                                        ],
+                                        [
+                                            1,
+                                            "DO-260A [Ref. 9"
+                                        ],
+                                        [
+                                            2,
+                                            "ED102A/DO-260B [Ref. 11]"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LTT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Link Technology Type",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Other"
+                                        ],
+                                        [
+                                            1,
+                                            "UAT"
+                                        ],
+                                        [
+                                            2,
+                                            "1090 ES"
+                                        ],
+                                        [
+                                            3,
+                                            "VDL 4"
+                                        ],
+                                        [
+                                            4,
+                                            "Not assigned"
+                                        ],
+                                        [
+                                            5,
+                                            "Not assigned"
+                                        ],
+                                        [
+                                            6,
+                                            "Not assigned"
+                                        ],
+                                        [
+                                            7,
+                                            "Not assigned"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Meteorological information.\n",
+            "description": null,
+            "name": "220",
+            "remark": null,
+            "spare": false,
+            "title": "Met Information",
+            "variation": {
+                "fspec": null,
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "WS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Wind Speed",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 0
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 300
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "kt"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 16,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "WD",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Wind Direction",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 1
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 360
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "deg"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 16,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TMP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Temperature",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": -100
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 100
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 2,
+                                    "scaling": {
+                                        "type": "Integer",
+                                        "value": 1
+                                    },
+                                    "signed": true,
+                                    "type": "Quantity",
+                                    "unit": "degC"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 16,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TRB",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Turbulence",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": ">=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 0
+                                            }
+                                        },
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Integer",
+                                                "value": 15
+                                            }
+                                        }
+                                    ],
+                                    "signed": false,
+                                    "type": "Integer"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Compound"
+            }
+        },
+        {
+            "definition": "The roll angle, in two’s complement form, of an aircraft executing a turn.\n",
+            "description": null,
+            "name": "230",
+            "remark": "Notes:\n\n    1. Negative Value indicates “Left Wing Down”.\n    2. Resolution provided by the technology “1090 MHz Extended Squitter”\n       is 1 degree.\n",
+            "spare": false,
+            "title": "Roll Angle",
+            "variation": {
+                "content": {
+                    "rule": {
+                        "constraints": [
+                            {
+                                "type": ">=",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": -180
+                                }
+                            },
+                            {
+                                "type": "<=",
+                                "value": {
+                                    "type": "Integer",
+                                    "value": 180
+                                }
+                            }
+                        ],
+                        "fractionalBits": 0,
+                        "scaling": {
+                            "type": "Real",
+                            "value": 1.0e-2
+                        },
+                        "signed": true,
+                        "type": "Quantity",
+                        "unit": "deg"
+                    },
+                    "type": "ContextFree"
+                },
+                "size": 16,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Mode S Comm B data as extracted from the aircraft transponder.\n",
+            "description": null,
+            "name": "250",
+            "remark": "Notes:\n\n    1. For the transmission of BDS20, item 170 should be used.\n    2. For the transmission of BDS30, item 260 is used.\n",
+            "spare": false,
+            "title": "Mode S MB Data",
+            "variation": {
+                "rep": 8,
+                "type": "Repetitive",
+                "variation": {
+                    "content": {
+                        "rule": {
+                            "type": "Bds"
+                        },
+                        "type": "ContextFree"
+                    },
+                    "size": 8,
+                    "type": "Element"
+                }
+            }
+        },
+        {
+            "definition": "Currently active Resolution Advisory (RA), if any, generated by the ACAS\nassociated with the transponder transmitting the RA message and threat\nidentity data.\n",
+            "description": null,
+            "name": "260",
+            "remark": "Notes:\n\n    1. Version denotes the MOPS version as defined in I021/210, bits 6/4\n    2. This data items copies the value of BDS register 6,1 for message\n       type 28, subtype 2\n    3. The “TYP” and “STYP” items are implementation (i.e. link technology)\n       dependent.\n    4. Refer to ICAO Annex 10 SARPs for detailed explanations [Ref. 10]\n",
+            "spare": false,
+            "title": "ACAS Resolution Advisory Report",
+            "variation": {
+                "items": [
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TYP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Message Type (= 28 for 1090 ES, version 2)",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 5,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "STYP",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Message Sub-type (= 2 for 1090 ES, version 2)",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 3,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "ARA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Active Resolution Advisories",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 14,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RAC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "RAC (RA Complement) Record",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 4,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RAT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "RA Terminated",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "MTE",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Multiple Threat Encounter",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TTI",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Threat Type Indicator",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 2,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "TID",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Threat Identity Data",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 26,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Group"
+            }
+        },
+        {
+            "definition": "Operational capabilities of the aircraft while on the ground.\n",
+            "description": null,
+            "name": "271",
+            "remark": "Notes:\n\n    1. Version 2 (as defined in I021/210, bits 6/4) data technology\n       protocols encode “No Data or Unknown” with value 0. In this\n       case data item I021/271, first extension is not generated.\n    2. As of edition 2.2 the structure of this data item has been changed.\n       Edition 2.2 is not backwards compatible with previous editions.\n",
+            "spare": false,
+            "title": "Surface Capabilities and Characteristics",
+            "variation": {
+                "extents": 8,
+                "first": 8,
+                "items": [
+                    {
+                        "length": 2,
+                        "spare": true
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "POA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Position Offset Applied",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Position transmitted is not ADS-B position reference point"
+                                        ],
+                                        [
+                                            1,
+                                            "Position transmitted is the ADS-B position reference point"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "CDTI_S",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Cockpit Display of Traffic Information Surface",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "CDTI not operational"
+                                        ],
+                                        [
+                                            1,
+                                            "CDTI operational"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "B2low",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Class B2 transmit power less than 70 Watts",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            ">= 70 Watts"
+                                        ],
+                                        [
+                                            1,
+                                            "< 70 Watts"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "RAS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Receiving ATC Services",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "Aircraft not receiving ATC-services"
+                                        ],
+                                        [
+                                            1,
+                                            "Aircraft receiving ATC services"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "IDENT",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Setting of 'IDENT'-switch",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "type": "Table",
+                                    "values": [
+                                        [
+                                            0,
+                                            "IDENT switch not active"
+                                        ],
+                                        [
+                                            1,
+                                            "IDENT switch active"
+                                        ]
+                                    ]
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 1,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": null,
+                        "name": "LW",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Length and width of the aircraft",
+                        "variation": {
+                            "content": {
+                                "type": "Unspecified"
+                            },
+                            "size": 4,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "length": 3,
+                        "spare": true
+                    }
+                ],
+                "type": "Extended"
+            }
+        },
+        {
+            "definition": "Ages of the data provided.\n",
+            "description": null,
+            "name": "295",
+            "remark": "Notes:\n\n    - In all the subfields, the maximum value indicates “maximum value\n      or above”.\n",
+            "spare": false,
+            "title": "Data Ages",
+            "variation": {
+                "fspec": null,
+                "items": [
+                    {
+                        "definition": null,
+                        "description": "Age of the information transmitted in item I021/008.\n",
+                        "name": "AOS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Aircraft Operational Status Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Target Report Descriptor, item I021/040\n",
+                        "name": "TRD",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Target Report Descriptor Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Mode 3/A Code, item I021/070\n",
+                        "name": "M3A",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Mode 3/A Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Quality Indicators, item I021/090\n",
+                        "name": "QI",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Quality Indicators Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Trajectory Intent information, item I021/110\n",
+                        "name": "TI1",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Trajectory Intent Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the message amplitude, item I021/132\n",
+                        "name": "MAM",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Message Amplitude Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Geometric Height, item 021/140\n",
+                        "name": "GH",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Geometric Height Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Flight Level, item I021/145\n",
+                        "name": "FL",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Flight Level Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Intermediate State Selected Altitude, item I021/146\n",
+                        "name": "ISA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Intermediate State Selected Altitude Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Final State Selected Altitude, item I021/148\n",
+                        "name": "FSA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Final State Selected Altitude Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Air Speed, item I021/150\n",
+                        "name": "AS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Air Speed Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the True Air Speed, item I021/151\n",
+                        "name": "TAS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "True Air Speed Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Magnetic Heading, item I021/152\n",
+                        "name": "MH",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Magnetic Heading Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Barometric Vertical Rate, item I021/155\n",
+                        "name": "BVR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Barometric Vertical Rate Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Geometric Vertical Rate, item I021/157\n",
+                        "name": "GVR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Geometric Vertical Rate Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Ground Vector, item I021/160\n",
+                        "name": "GV",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Ground Vector Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Track Angle Rate, item I021/165\n",
+                        "name": "TAR",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Track Angle Rate Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Target Identification, item I021/170\n",
+                        "name": "TI2",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Target Identification Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Target Status, item I021/200\n",
+                        "name": "TS",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Target Status Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Meteorological Information, item I021/220\n",
+                        "name": "MET",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Met Information Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the Roll Angle, item I021/230\n",
+                        "name": "ROA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Roll Angle Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the latest update of an active ACAS Resolution Advisory,\nitem I021/260\n",
+                        "name": "ARA",
+                        "remark": null,
+                        "spare": false,
+                        "title": "ACAS Resolution Advisory Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    },
+                    {
+                        "definition": null,
+                        "description": "Age of the information on the surface capabilities and\ncharacteristics of the respective target, item I021/271\n",
+                        "name": "SCC",
+                        "remark": null,
+                        "spare": false,
+                        "title": "Surface Capabilities and Characteristics Age",
+                        "variation": {
+                            "content": {
+                                "rule": {
+                                    "constraints": [
+                                        {
+                                            "type": "<=",
+                                            "value": {
+                                                "type": "Real",
+                                                "value": 25.5
+                                            }
+                                        }
+                                    ],
+                                    "fractionalBits": 0,
+                                    "scaling": {
+                                        "type": "Real",
+                                        "value": 0.1
+                                    },
+                                    "signed": false,
+                                    "type": "Quantity",
+                                    "unit": "s"
+                                },
+                                "type": "ContextFree"
+                            },
+                            "size": 8,
+                            "type": "Element"
+                        }
+                    }
+                ],
+                "type": "Compound"
+            }
+        },
+        {
+            "definition": "Designator of Ground Station in Distributed System.\n",
+            "description": null,
+            "name": "400",
+            "remark": null,
+            "spare": false,
+            "title": "Receiver ID",
+            "variation": {
+                "content": {
+                    "type": "Unspecified"
+                },
+                "size": 8,
+                "type": "Element"
+            }
+        },
+        {
+            "definition": "Expansion\n",
+            "description": null,
+            "name": "RE",
+            "remark": null,
+            "spare": false,
+            "title": "Reserved Expansion Field",
+            "variation": {
+                "type": "Explicit"
+            }
+        },
+        {
+            "definition": "Special Purpose Field\n",
+            "description": null,
+            "name": "SP",
+            "remark": null,
+            "spare": false,
+            "title": "Special Purpose Field",
+            "variation": {
+                "type": "Explicit"
+            }
+        }
+    ],
+    "date": {
+        "day": 15,
+        "month": 6,
+        "year": 2015
+    },
+    "edition": {
+        "major": 2,
+        "minor": 4
+    },
+    "number": 21,
+    "preamble": "Surveillance data exchange.\nADS-B Target Reports.\n",
+    "title": "ADS-B Target Reports",
+    "type": "Basic",
+    "uap": {
+        "items": [
+            "010",
+            "040",
+            "161",
+            "015",
+            "071",
+            "130",
+            "131",
+            "072",
+            "150",
+            "151",
+            "080",
+            "073",
+            "074",
+            "075",
+            "076",
+            "140",
+            "090",
+            "210",
+            "070",
+            "230",
+            "145",
+            "152",
+            "200",
+            "155",
+            "157",
+            "160",
+            "165",
+            "077",
+            "170",
+            "020",
+            "220",
+            "146",
+            "148",
+            "110",
+            "016",
+            "008",
+            "271",
+            "132",
+            "250",
+            "260",
+            "400",
+            "295",
+            null,
+            null,
+            null,
+            null,
+            null,
+            "RE",
+            "SP"
+        ],
+        "type": "uap"
+    }
+}

--- a/asterix-specs-converter/cat021_ref-1.4.json
+++ b/asterix-specs-converter/cat021_ref-1.4.json
@@ -1,0 +1,1312 @@
+{
+    "date": {
+        "day": 8,
+        "month": 3,
+        "year": 2018
+    },
+    "edition": {
+        "major": 1,
+        "minor": 4
+    },
+    "number": 21,
+    "title": "ADS-B Target Reports Expansion",
+    "type": "Expansion",
+    "variation": {
+        "fspec": 8,
+        "items": [
+            {
+                "definition": "Barometric Pressure Setting\n",
+                "description": null,
+                "name": "BPS",
+                "remark": "Notes:\n\n    - BPS is the barometric pressure setting of the aircraft minus 800 hPa\n\n    - A value of \"0\" indicates that in the aircraft a value of 800 hPa or\n      less has been selected.\n\n    - A value of \"409.5\" indicates that in the aircraft a value of 1209.5\n      hPa or more has been selected.\n",
+                "spare": false,
+                "title": "Barometric Pressure Setting",
+                "variation": {
+                    "items": [
+                        {
+                            "length": 4,
+                            "spare": true
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "BPS",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Barometric Pressure Setting",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "constraints": [
+                                            {
+                                                "type": ">=",
+                                                "value": {
+                                                    "type": "Integer",
+                                                    "value": 0
+                                                }
+                                            },
+                                            {
+                                                "type": "<=",
+                                                "value": {
+                                                    "type": "Real",
+                                                    "value": 409.5
+                                                }
+                                            }
+                                        ],
+                                        "fractionalBits": 0,
+                                        "scaling": {
+                                            "type": "Real",
+                                            "value": 0.1
+                                        },
+                                        "signed": false,
+                                        "type": "Quantity",
+                                        "unit": "hPa"
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 12,
+                                "type": "Element"
+                            }
+                        }
+                    ],
+                    "type": "Group"
+                }
+            },
+            {
+                "definition": "Selected Heading\n",
+                "description": null,
+                "name": "SelH",
+                "remark": "On many aircraft, the ADS-B Transmitting Subsystem receives\nSelected Heading from a Mode Control Panel / Flight Control Unit\n(MCP / FCU). Users of this data are cautioned that the Selected\nHeading value transmitted by the ADS-B Transmitting Subsystem\ndoes not necessarily reflect the true intention of the airplane during\ncertain flight modes (e.g., during LNAV mode).\n",
+                "spare": false,
+                "title": "Selected Heading",
+                "variation": {
+                    "items": [
+                        {
+                            "length": 4,
+                            "spare": true
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "HDR",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Horizontal Reference Direction",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "True North"
+                                            ],
+                                            [
+                                                1,
+                                                "Magnetic North"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "Stat",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Selected Heading Status",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Data is either unavailable or invalid."
+                                            ],
+                                            [
+                                                1,
+                                                "Data is available and valid."
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "SelH",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Selected Heading",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "constraints": [],
+                                        "fractionalBits": 6,
+                                        "scaling": {
+                                            "type": "Integer",
+                                            "value": 45
+                                        },
+                                        "signed": false,
+                                        "type": "Quantity",
+                                        "unit": "deg"
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 10,
+                                "type": "Element"
+                            }
+                        }
+                    ],
+                    "type": "Group"
+                }
+            },
+            {
+                "definition": "Navigation Mode Settings\n",
+                "description": null,
+                "name": "NAV",
+                "remark": "This data-item should only be transmitted if an ADS-B indication has\nbeen received that the mode bits have been \"actively populated\".by\nthe avionics (1090 ES version 2 (as defined in I021/210) BDS 6,2,\nsubtype 1, bit 47: \"Status of MCP / FCU Mode Bits\")\n",
+                "spare": false,
+                "title": "Navigation Mode",
+                "variation": {
+                    "items": [
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "AP",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Autopilot",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Autopilot not engaged"
+                                            ],
+                                            [
+                                                1,
+                                                "Autopilot engaged"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "VN",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Vertical Navigation",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Vertical Navigation not active"
+                                            ],
+                                            [
+                                                1,
+                                                "Vertical Navigation active"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "AH",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Altitude Hold",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Altitude Hold not engaged"
+                                            ],
+                                            [
+                                                1,
+                                                "Altitude Hold engaged"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "AM",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Approach Mode",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Approach Mode not active"
+                                            ],
+                                            [
+                                                1,
+                                                "Approach Mode active"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "length": 4,
+                            "spare": true
+                        }
+                    ],
+                    "type": "Group"
+                }
+            },
+            {
+                "definition": "GPS Antenna Offset\n",
+                "description": null,
+                "name": "GAO",
+                "remark": "The value of this field is copied from the respective bits 33-40 of\nversion 2 (as defined in I021/210) of 1090 ES BDS register 6,5\n(Aircraft Operational Status)\n",
+                "spare": false,
+                "title": "GPS Antenna Offset",
+                "variation": {
+                    "content": {
+                        "type": "Unspecified"
+                    },
+                    "size": 8,
+                    "type": "Element"
+                }
+            },
+            {
+                "definition": "Ground Speed and Track Angle elements of the Surface\nGround Vector.\n",
+                "description": null,
+                "name": "SGV",
+                "remark": null,
+                "spare": false,
+                "title": "Surface Ground Vector",
+                "variation": {
+                    "extents": 8,
+                    "first": 16,
+                    "items": [
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "STP",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Aircraft has not stopped"
+                                            ],
+                                            [
+                                                1,
+                                                "Aircraft has stopped"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "HTS",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Heading/Ground Track data is not valid"
+                                            ],
+                                            [
+                                                1,
+                                                "Heading/Ground Track data is valid"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "HTT",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Heading data provided"
+                                            ],
+                                            [
+                                                1,
+                                                "Ground Track provided"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "HRD",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "True North"
+                                            ],
+                                            [
+                                                1,
+                                                "Magnetic North"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "GSS",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Ground speed",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "constraints": [],
+                                        "fractionalBits": 3,
+                                        "scaling": {
+                                            "type": "Integer",
+                                            "value": 1
+                                        },
+                                        "signed": false,
+                                        "type": "Quantity",
+                                        "unit": "kts"
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 11,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "HGT",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Heading/Ground Track information",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "constraints": [],
+                                        "fractionalBits": 4,
+                                        "scaling": {
+                                            "type": "Integer",
+                                            "value": 45
+                                        },
+                                        "signed": false,
+                                        "type": "Quantity",
+                                        "unit": "deg"
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 7,
+                                "type": "Element"
+                            }
+                        }
+                    ],
+                    "type": "Extended"
+                }
+            },
+            {
+                "definition": "This item contains flags to convey information on the status\nof a target.\n",
+                "description": null,
+                "name": "STA",
+                "remark": null,
+                "spare": false,
+                "title": "Aircraft Status",
+                "variation": {
+                    "extents": 8,
+                    "first": 8,
+                    "items": [
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "ES",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Target is not 1090 ES IN capable"
+                                            ],
+                                            [
+                                                1,
+                                                "Target is 1090 ES IN capable"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "UAT",
+                            "remark": null,
+                            "spare": false,
+                            "title": "",
+                            "variation": {
+                                "content": {
+                                    "rule": {
+                                        "type": "Table",
+                                        "values": [
+                                            [
+                                                0,
+                                                "Target is not UAT IN capable"
+                                            ],
+                                            [
+                                                1,
+                                                "Target is UAT IN capable"
+                                            ]
+                                        ]
+                                    },
+                                    "type": "ContextFree"
+                                },
+                                "size": 1,
+                                "type": "Element"
+                            }
+                        },
+                        {
+                            "length": 5,
+                            "spare": true
+                        }
+                    ],
+                    "type": "Extended"
+                }
+            },
+            {
+                "definition": "True North Heading (Element of Air Vector).\n",
+                "description": null,
+                "name": "TNH",
+                "remark": "Magnetic Heading is defined in I021/152.\n",
+                "spare": false,
+                "title": "True North Heading",
+                "variation": {
+                    "content": {
+                        "rule": {
+                            "constraints": [],
+                            "fractionalBits": 16,
+                            "scaling": {
+                                "type": "Integer",
+                                "value": 360
+                            },
+                            "signed": false,
+                            "type": "Quantity",
+                            "unit": "deg"
+                        },
+                        "type": "ContextFree"
+                    },
+                    "size": 16,
+                    "type": "Element"
+                }
+            },
+            {
+                "definition": "Contents of Extended Squitters transmitted by Military Aircraft\n",
+                "description": null,
+                "name": "MES",
+                "remark": "Notes:\n\n    - The Reserved Expansion Field is optional. When used to transmit MES, it shall\n      be sent when the targets are represented by Mode 5 Level 2 reports.\n\n    - The information contained in this data item is specific to\n      1090MHz Extended Squitter messages transmitted by military\n      aircraft (Mode 5 Level 2 squitter).\n",
+                "spare": false,
+                "title": "Military Extended Squitter",
+                "variation": {
+                    "fspec": null,
+                    "items": [
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "SUM",
+                            "remark": "Notes:\n\n    1. The flag M2 refers to the contents of Subfield #6 below, M3, MC refer\n       to the contents of data items I021/070 and I021/145 respectively. The\n       flag M1 refers to the contents of Subfield #3 below (Extended Mode 1\n       Code in Octal Representation).\n\n    2. If a Mode 5 reply/report is received with the Emergency bit set, then\n       the Military Emergency bit (ME) in Data Item I021/200, Target Status,\n       shall be set.\n\n    3. If a Mode 5 reply/report is received with the Identification of Position bit\n       set, then the Special Position Identification bit (SPI) in Data Item\n       I021/200, Target Status, shall be set.\n\n    4. If a Mode 5 report (ID or Data) is received and fullfill the autentication\n       criteria the corresponding authentication bit shall be set.\n",
+                            "spare": false,
+                            "title": "Mode 5 Summary",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "M5",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "No Mode 5 interrogation"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Mode 5 interrogation"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "ID",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "No authenticated Mode 5 ID reply/report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Authenticated Mode 5 ID reply/report"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "DA",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "No authenticated Mode 5 Data reply or Report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Authenticated Mode 5 Data reply or Report (i.e any valid Mode 5 reply type other than ID)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "M1",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Mode 1 code not present or not from Mode 5 reply/report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Mode 1 code from Mode 5 reply/report."
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "M2",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Mode 2 code not present or not from Mode 5 reply/report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Mode 2 code from Mode 5 reply/report."
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "M3",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Mode 3 code not present or not from Mode 5 reply/report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Mode 3 code from Mode 5 reply/report."
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "MC",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Flightlevel not present or not from Mode 5 reply/report"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Flightlevel from Mode 5 reply/report"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "PO",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Position not from Mode 5 report (ADS-B report)"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Position from Mode 5 report"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "PNO",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Mode 5 PIN /National Origin",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "length": 2,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "PIN",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "PIN Code",
+                                        "variation": {
+                                            "content": {
+                                                "type": "Unspecified"
+                                            },
+                                            "size": 14,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "length": 5,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "NO",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "National Origin Code",
+                                        "variation": {
+                                            "content": {
+                                                "type": "Unspecified"
+                                            },
+                                            "size": 11,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "EM1",
+                            "remark": "Notes:\n\n    - Subfield #1 is present, the M1 bit in Subfield #1 indicates whether the\n      Extended Mode 1 Code is from a Mode 5 reply or a Mode 1 reply. If\n      Subfield #1 is not present, the Extended Mode 1 Code is from a Mode\n      1 reply.\n\n    - If Subfield #3 is not present the Mode 1 Code was not reported or all\n      Code Bits were equal to 0.\n\n    - The valid bit is set if the Code was only reported once for that target.\n",
+                            "spare": false,
+                            "title": "Extended Mode 1 Code in Octal Representation",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "V",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Code validated"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Code not validated"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "length": 1,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "L",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Mode 1 code as derived from the report of the transponder"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Smoothed Mode 1 code as provided by a local tracker"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "length": 1,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "EM1",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Extended Mode 1 Code in Octal Representation",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "String",
+                                                    "variation": "StringOctal"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 12,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "XP",
+                            "remark": "Within Mode 5 reports, the X-Pulse can be set for the following cases:\n\n1. In a combined Mode 1 and Mode 2 report: in this case the X5 bit and the X2 bit\nshall be set;\n\n2. In a combined Mode 3 and Mode C report: in this case the X5 bit and the X3\nbit shall be set;\n\n3. In a Mode 5 PIN data report: in this case the X5 bit and the XP bit shall be set.\nThe X1 bit and the XC bit are meaningless as in Mode 1 and Mode C\nreplies/reports the X Pulse is not defined. They are kept for compatibility\nreasons.\n",
+                            "spare": false,
+                            "title": "X Pulse Presence",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "length": 2,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "XP",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode 5 PIN reply/report",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "X-Pulse not present."
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse present."
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "X5",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode 5 Data reply or Report.",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "X-pulse set to zero or no authenticated Data reply or Report received."
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse set to one (present)."
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "XC",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode C reply",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "X-pulse set to zero or no Mode C reply"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse set to one (present)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "X3",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode 3/A reply",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "X-pulse set to zero or no Mode 3/A reply\""
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse set to one (present)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "X2",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode 2 reply",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "0 X-pulse set to zero or no Mode 2 reply"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse set to one (present)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "X1",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "X-pulse from Mode 1 reply",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "X-pulse set to zero or no Mode 1 reply"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "X-pulse set to one (present)"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "FOM",
+                            "remark": null,
+                            "spare": false,
+                            "title": "Figure of Merit",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "length": 3,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "FOM",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Figure of Merit",
+                                        "variation": {
+                                            "content": {
+                                                "type": "Unspecified"
+                                            },
+                                            "size": 5,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        },
+                        {
+                            "definition": null,
+                            "description": null,
+                            "name": "M2",
+                            "remark": "If Subfield 6 is not present the Mode 2 Code was no reported or all\nCode Bits were equal to 0.\n",
+                            "spare": false,
+                            "title": "Mode 2 Code in Octal Representation",
+                            "variation": {
+                                "items": [
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "V",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Code validated"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Code not validated"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "length": 1,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "L",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "Table",
+                                                    "values": [
+                                                        [
+                                                            0,
+                                                            "Mode 1 code as derived from the report of the transponder"
+                                                        ],
+                                                        [
+                                                            1,
+                                                            "Smoothed Mode 1 code as provided by a local tracker"
+                                                        ]
+                                                    ]
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 1,
+                                            "type": "Element"
+                                        }
+                                    },
+                                    {
+                                        "length": 1,
+                                        "spare": true
+                                    },
+                                    {
+                                        "definition": null,
+                                        "description": null,
+                                        "name": "ABCD",
+                                        "remark": null,
+                                        "spare": false,
+                                        "title": "Mode 2 Code in Octal Representation",
+                                        "variation": {
+                                            "content": {
+                                                "rule": {
+                                                    "type": "String",
+                                                    "variation": "StringOctal"
+                                                },
+                                                "type": "ContextFree"
+                                            },
+                                            "size": 12,
+                                            "type": "Element"
+                                        }
+                                    }
+                                ],
+                                "type": "Group"
+                            }
+                        }
+                    ],
+                    "type": "Compound"
+                }
+            }
+        ],
+        "type": "Compound"
+    }
+}


### PR DESCRIPTION
Category and RE definitions can be merged to the same xml output.
See README.md file for usage.

Check generated XML files:
* cat011 (without RE)
* cat021 (with defined RE). This category might need item renames or other fixes.
Item renames is possible using the dict at the top of the conversion script. Extend as necessary.
