### PR TITLE
Add missing Single Antenna (SA) element in Data Item I021/008 for CAT021 v2.1

### DIFF
--- a/asterix/config/asterix_cat021_2_4.xml
+++ b/asterix/config/asterix_cat021_2_4.xml
@@ -29,7 +29,7 @@
                 </Bits>
                 <Bits from="7" to="6">
                     <BitsShortName>TC</BitsShortName>
-                    <BitsName>Target Change Report Capability</BitsName>
+                    <BitsName>Target Trajectory Change Report Capability</BitsName>
                     <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
                     <BitsValue val="1">support for TC+0 reports only</BitsValue>
                     <BitsValue val="2">support for multiple TC reports</BitsValue>

--- a/install/config/asterix_cat021_2_1_RE_1_1.xml
+++ b/install/config/asterix_cat021_2_1_RE_1_1.xml
@@ -27,7 +27,7 @@
                 </Bits>
                 <Bits from="7" to="6">
                     <BitsShortName>TC</BitsShortName>
-                    <BitsName>Target Change Report Capability</BitsName>
+                    <BitsName>Target Trajectory Change Report Capability</BitsName>
                     <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
                     <BitsValue val="1">support for TC+0 reports only</BitsValue>
                     <BitsValue val="2">support for multiple TC reports</BitsValue>

--- a/install/config/asterix_cat021_2_1_RE_1_1.xml
+++ b/install/config/asterix_cat021_2_1_RE_1_1.xml
@@ -58,8 +58,10 @@
                     <BitsValue val="1">TCAS not installed or not operational</BitsValue>
                 </Bits>
                 <Bits bit="1">
-                    <BitsShortName>spare</BitsShortName>
-                    <BitsName>spare bit, set to 0</BitsName>
+                    <BitsShortName>SA</BitsShortName>
+                    <BitsName>Single Antenna</BitsName>
+                    <BitsValue val="0">Antenna Diversity</BitsValue>
+                    <BitsValue val="1">Single Antenna only</BitsValue>
                 </Bits>
             </Fixed>
         </DataItemFormat>

--- a/install/config/asterix_cat021_2_4.xml
+++ b/install/config/asterix_cat021_2_4.xml
@@ -29,7 +29,7 @@
                 </Bits>
                 <Bits from="7" to="6">
                     <BitsShortName>TC</BitsShortName>
-                    <BitsName>Target Change Report Capability</BitsName>
+                    <BitsName>Target Trajectory Change Report Capability</BitsName>
                     <BitsValue val="0">no capability for Trajectory Change Reports</BitsValue>
                     <BitsValue val="1">support for TC+0 reports only</BitsValue>
                     <BitsValue val="2">support for multiple TC reports</BitsValue>


### PR DESCRIPTION
This PR adds the missing "Single Antenna" (SA) element in Data Item I021/008 for ASTERIX CAT021 v2.1

Until [v1.8](https://www.eurocontrol.int/sites/default/files/2019-06/asterix-cat021-asterix-ads-b-messages-part-12-v1.8-012011.pdf), bit 1 of  Data Item I021/008 was spare bit set to 0, but starting from [v2.1](https://www.eurocontrol.int/sites/default/files/content/documents/nm/asterix/part2-cat021-asterix-ads-b-messages-part-12.pdf), bit 1 is used for the "Single Antenna" element.