### PR TITLE
convert timestamp to double, improves precision

### DIFF
--- a/src/asterix/DataBlock.cpp
+++ b/src/asterix/DataBlock.cpp
@@ -28,7 +28,7 @@
 
 extern bool gFiltering;
 
-DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data, unsigned long nTimestamp)
+DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp)
         : m_pCategory(cat), m_nLength(len), m_nTimestamp(nTimestamp), m_bFormatOK(false) {
     const unsigned char *m_pItemDataStart = data;
     long nUnparsed = len;
@@ -40,7 +40,7 @@ DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data
     }
 
     while (nUnparsed > 0) {
-        DataRecord *dr = new DataRecord(cat, counter++, nUnparsed, m_pItemDataStart, (unsigned long) nTimestamp);
+        DataRecord *dr = new DataRecord(cat, counter++, nUnparsed, m_pItemDataStart, nTimestamp);
 
         if (!dr) {
             Tracer::Error("Error DataBlock format.");

--- a/src/asterix/DataBlock.cpp
+++ b/src/asterix/DataBlock.cpp
@@ -85,6 +85,7 @@ bool DataBlock::getText(std::string &strResult, const unsigned int formatType) {
         case CAsterixFormat::ETxt:
             strResult += format("\nCategory: %d", m_pCategory->m_id);
             strResult += format("\nLen: %ld", m_nLength);
+            strResult += format("\nTimestamp: %lf", m_nTimestamp);
             strResult += format("\nHexData: %02X%02X%02X", m_pCategory->m_id, ((m_nLength + 3) >> 8) & 0xff, (m_nLength + 3) & 0xff);
             break;
         case CAsterixFormat::EOut:

--- a/src/asterix/DataBlock.h
+++ b/src/asterix/DataBlock.h
@@ -28,14 +28,14 @@
 
 class DataBlock {
 public:
-    DataBlock(Category *cat, unsigned long len, const unsigned char *data, unsigned long nTimestamp = 0);
+    DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp = 0.0);
 
     virtual
     ~DataBlock();
 
     Category *m_pCategory;
     unsigned long m_nLength;
-    unsigned long m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    double m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
     bool m_bFormatOK;
 
     std::list<DataRecord *> m_lDataRecords;

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -172,19 +172,18 @@ bool DataRecord::getText(std::string &strResult, std::string &strHeader, const u
             strNewResult = format("\n-------------------------\nData Record %d", m_nID);
             strNewResult += format("\nLen: %ld", m_nLength);
             strNewResult += format("\nCRC: %08X", m_nCrc);
-            strNewResult += format("\nTimestamp: %lf", m_nTimestamp);
             strNewResult += format("\nHexData: %s", m_pHexData);
             break;
         case CAsterixFormat::EJSON:
             strNewResult = format(
-                    "{\"id\":%d,\"length\":%ld,\"crc\":\"%08X\",\"timestamp\":%lf,\"hexdata\":\"%s\",\"CAT%03d\":{",
-                    m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+                    "{\"id\":%d,\"cat\":%d,\"length\":%ld,\"crc\":\"%08X\",\"timestamp\":%lf,\"hexdata\":\"%s\",\"CAT%03d\":{",
+                    m_nID, m_pCategory->m_id, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
             break;
         case CAsterixFormat::EJSONH:
         case CAsterixFormat::EJSONE:
             strNewResult = format(
-                    "{\"id\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%lf,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n",
-                    m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
+                    "{\"id\":%d,\n\"cat\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%lf,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n",
+                    m_nID, m_pCategory->m_id, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
             break;
         case CAsterixFormat::EXML:
         case CAsterixFormat::EXMLH: {

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -27,7 +27,7 @@
 #include "Utils.h"
 #include "asterixformat.hxx"
 
-DataRecord::DataRecord(Category *cat, int nID, unsigned long len, const unsigned char *data, unsigned long nTimestamp)
+DataRecord::DataRecord(Category *cat, int nID, unsigned long len, const unsigned char *data, double nTimestamp)
         : m_pCategory(cat), m_nID(nID), m_nLength(len), m_nFSPECLength(0), m_pFSPECData(NULL), m_nTimestamp(nTimestamp),
           m_nCrc(0), m_pHexData(NULL), m_bFormatOK(false) {
     const unsigned char *m_pItemDataStart = data;
@@ -172,25 +172,25 @@ bool DataRecord::getText(std::string &strResult, std::string &strHeader, const u
             strNewResult = format("\n-------------------------\nData Record %d", m_nID);
             strNewResult += format("\nLen: %ld", m_nLength);
             strNewResult += format("\nCRC: %08X", m_nCrc);
-            strNewResult += format("\nTimestamp: %ld", m_nTimestamp);
+            strNewResult += format("\nTimestamp: %lf", m_nTimestamp);
             strNewResult += format("\nHexData: %s", m_pHexData);
             break;
         case CAsterixFormat::EJSON:
             strNewResult = format(
-                    "{\"id\":%d,\"length\":%ld,\"crc\":\"%08X\",\"timestamp\":%ld,\"hexdata\":\"%s\",\"CAT%03d\":{",
+                    "{\"id\":%d,\"length\":%ld,\"crc\":\"%08X\",\"timestamp\":%lf,\"hexdata\":\"%s\",\"CAT%03d\":{",
                     m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
             break;
         case CAsterixFormat::EJSONH:
         case CAsterixFormat::EJSONE:
             strNewResult = format(
-                    "{\"id\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%ld,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n",
+                    "{\"id\":%d,\n\"length\":%ld,\n\"crc\":\"%08X\",\n\"timestamp\":%lf,\n\"hexdata\":\"%s\",\n\"CAT%03d\":{\n",
                     m_nID, m_nLength, m_nCrc, m_nTimestamp, m_pHexData, m_pCategory->m_id);
             break;
         case CAsterixFormat::EXML:
         case CAsterixFormat::EXMLH: {
             const int nXIDEFv = 1;
             strNewResult = format(
-                    "<ASTERIX ver=\"%d\" cat=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%ld\" hexdata=\"%s\">",
+                    "<ASTERIX ver=\"%d\" cat=\"%d\" length=\"%ld\" crc=\"%08X\" timestamp=\"%lf\" hexdata=\"%s\">",
                     nXIDEFv, m_pCategory->m_id, m_nLength, m_nCrc, m_nTimestamp, m_pHexData);
             break;
         }

--- a/src/asterix/DataRecord.h
+++ b/src/asterix/DataRecord.h
@@ -28,7 +28,7 @@
 
 class DataRecord {
 public:
-    DataRecord(Category *cat, int id, unsigned long len, const unsigned char *data, unsigned long nTimestamp);
+    DataRecord(Category *cat, int id, unsigned long len, const unsigned char *data, double nTimestamp);
 
     virtual
     ~DataRecord();
@@ -38,7 +38,7 @@ public:
     unsigned long m_nLength;
     unsigned long m_nFSPECLength;
     unsigned char *m_pFSPECData;
-    unsigned long m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    double m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
     uint32_t m_nCrc;
     char *m_pHexData; // hexa conversion of data to display
     bool m_bFormatOK;

--- a/src/asterix/InputParser.cpp
+++ b/src/asterix/InputParser.cpp
@@ -35,7 +35,7 @@ InputParser::InputParser(AsterixDefinition *pDefinition)
  * Parse data
  */
 AsterixData *
-InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, unsigned long nTimestamp) {
+InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp) {
     AsterixData *pAsterixData = new AsterixData();
     unsigned int m_nPos = 0;
     unsigned int m_nDataLength = 0;
@@ -116,7 +116,7 @@ InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferS
 
 DataBlock *
 InputParser::parse_next_data_block(const unsigned char *m_pData, unsigned int &m_nPos, unsigned int m_nBufferSize,
-                                   unsigned long nTimestamp, unsigned int &m_nDataLength)
+                                   double nTimestamp, unsigned int &m_nDataLength)
 /*  parse next data block
  *  AUTHOR: Krzysztof Rutkowski, ICM UW, krutk@icm.edu.pl
  */

--- a/src/asterix/InputParser.h
+++ b/src/asterix/InputParser.h
@@ -38,10 +38,10 @@ public:
 
     ~InputParser() { if (m_pDefinition) delete m_pDefinition; }
 
-    AsterixData *parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, unsigned long nTimestamp = 0);
+    AsterixData *parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp = 0.0);
 
     DataBlock *parse_next_data_block(const unsigned char *m_pData, unsigned int &m_nPos, unsigned int m_nBufferSize,
-                                     unsigned long nTimestamp, unsigned int &m_nDataLength);
+                                     double nTimestamp, unsigned int &m_nDataLength);
 
     std::string printDefinition();
 

--- a/src/asterix/asterixformatdescriptor.hxx
+++ b/src/asterix/asterixformatdescriptor.hxx
@@ -102,11 +102,11 @@ public:
     }
 
     // used only when format is GPS
-    unsigned long GetTimeStamp() {
+    double GetTimeStamp() {
         return m_nTimeStamp;
     }
 
-    void SetTimeStamp(unsigned long ts) {
+    void SetTimeStamp(double ts) {
         m_nTimeStamp = ts;
     }
 
@@ -131,7 +131,7 @@ private:
     const unsigned char *m_pBuffer; // input buffer
     unsigned int m_nBufferSize; // input buffer size
     unsigned int m_nDataSize; // size of data in buffer
-    unsigned long m_nTimeStamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    double m_nTimeStamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
 };
 
 #endif

--- a/src/asterix/asterixgpssubformat.cxx
+++ b/src/asterix/asterixgpssubformat.cxx
@@ -153,15 +153,14 @@ bool CAsterixGPSSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, C
                 return false;
             }
 
-            float fTimeStamp = ((GPSPost[6] << 16) + (GPSPost[7] << 8) + (GPSPost[8])) / 128.0;
-            unsigned long nTimeStamp = ((long) fTimeStamp) * 1000 + (fTimeStamp - ((long) fTimeStamp)) * 1000;
+            double dTimeStamp = ((GPSPost[6] << 16) + (GPSPost[7] << 8) + (GPSPost[8])) / 128.0;
 #ifdef _DEBUG
             LOGDEBUG(1, "GPS Bytes [%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]\n", GPSPost[0], GPSPost[1],
                 GPSPost[2], GPSPost[3], GPSPost[4], GPSPost[5], GPSPost[6], GPSPost[7],
                 GPSPost[8], GPSPost[9]);
-            LOGDEBUG(1, "GPS Timestamp [%3.4f]\n", fTimeStamp);
+            LOGDEBUG(1, "GPS Timestamp [%lf]\n", dTimeStamp);
 #endif
-            Descriptor.SetTimeStamp(nTimeStamp);
+            Descriptor.SetTimeStamp(dTimeStamp);
 
         }
     }
@@ -198,7 +197,7 @@ bool CAsterixGPSSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
         // get current timstamp in ms since midnight
         struct timeval tp;
         gettimeofday(&tp, NULL);
-        unsigned long nTimestamp = (tp.tv_sec % 86400) * 1000 + tp.tv_usec / 1000;
+	double dTimestamp = tp.tv_sec + (1.0/1000000) * tp.tv_usec;
 
         unsigned char *pPacketPtr = (unsigned char *) Descriptor.GetBuffer();
         int m_nDataLength = Descriptor.GetBufferLen();
@@ -226,7 +225,7 @@ bool CAsterixGPSSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
 
             // Parse ASTERIX data
             AsterixData *m_ptmpAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, byteCount - 6,
-                                                                                  nTimestamp);
+                                                                                  dTimestamp);
 
             if (Descriptor.m_pAsterixData == NULL) {
                 Descriptor.m_pAsterixData = m_ptmpAsterixData;
@@ -239,9 +238,9 @@ bool CAsterixGPSSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
             m_nDataLength -= byteCount;
         }
     } else {
-        unsigned long nTimeStamp = Descriptor.GetTimeStamp();
+        double dTimeStamp = Descriptor.GetTimeStamp();
         Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(Descriptor.GetBuffer(),
-                                                                         Descriptor.GetBufferLen(), nTimeStamp);
+                                                                         Descriptor.GetBufferLen(), dTimeStamp);
     }
 
     return true;

--- a/src/asterix/asterixrawsubformat.cxx
+++ b/src/asterix/asterixrawsubformat.cxx
@@ -160,7 +160,7 @@ bool CAsterixRawSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
     // get current timstamp in ms since midnight
     struct timeval tp;
     gettimeofday(&tp, NULL);
-    unsigned long nTimestamp = (tp.tv_sec % 86400) * 1000 + tp.tv_usec / 1000;
+    double dTimestamp = tp.tv_sec + (1.0/1000000.0) * tp.tv_usec;
 
     // parse packet
     if (oradis) {
@@ -190,7 +190,7 @@ bool CAsterixRawSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
 
             // Parse ASTERIX data
             AsterixData *m_ptmpAsterixData = Descriptor.m_InputParser.parsePacket(pPacketPtr, byteCount - 6,
-                                                                                  nTimestamp);
+                                                                                  dTimestamp);
 
             if (Descriptor.m_pAsterixData == NULL) {
                 Descriptor.m_pAsterixData = m_ptmpAsterixData;
@@ -204,7 +204,7 @@ bool CAsterixRawSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
         }
     } else {
         Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(Descriptor.GetBuffer(),
-                                                                         Descriptor.GetBufferLen(), nTimestamp);
+                                                                         Descriptor.GetBufferLen(), dTimestamp);
     }
 
     return true;


### PR DESCRIPTION
Instead of seconds*1000+usec/1000 as timestamp, use double representation as seconds with decimals.

No conversion has to be done when parsing output (timestamp can be compared directly to time of day dataitem, for example). 

Also, there is no loss of precision when transforming final format to timestamp.

Altought this works for me, I don't know if this PR will break things, please review with care.