### PR TITLE
Fixed duplicate field names in I001/060 and I252/110

### DIFF
--- a/asterix/config/asterix_cat001_1_2.xml
+++ b/asterix/config/asterix_cat001_1_2.xml
@@ -510,12 +510,12 @@
                     <BitsValue val="1">Low quality pulse</BitsValue>
                 </Bits>
                 <Bits bit="2">
-                    <BitsShortName>QB1</BitsShortName>
+                    <BitsShortName>QB4</BitsShortName>
                     <BitsValue val="0">High quality pulse</BitsValue>
                     <BitsValue val="1">Low quality pulse</BitsValue>
                 </Bits>
                 <Bits bit="1">
-                    <BitsShortName>QD1</BitsShortName>
+                    <BitsShortName>QD4</BitsShortName>
                     <BitsValue val="0">High quality pulse</BitsValue>
                     <BitsValue val="1">Low quality pulse</BitsValue>
                 </Bits>

--- a/asterix/config/asterix_cat252_7_0.xml
+++ b/asterix/config/asterix_cat252_7_0.xml
@@ -396,7 +396,7 @@
                         <BitsValue val="1">Yes</BitsValue>
                     </Bits>
                     <Bits bit="5">
-                        <BitsShortName>C4</BitsShortName>
+                        <BitsShortName>C5</BitsShortName>
                         <BitsName>Complementary service 5</BitsName>
                         <BitsValue val="0">No</BitsValue>
                         <BitsValue val="1">Yes</BitsValue>


### PR DESCRIPTION
Category 001, Data Item I001/100 have duplicate field names `QB1` and `QD1`. In the spec, they are named `QB4` and `QD4` instead.

Category 252, Data Item I001/110 has a duplicate field `C4`, but from long field name, it's clear that it should be named `C5`.