### PR TITLE
Make available in the output the source ip of the datablock 

### DIFF
--- a/src/asterix/DataBlock.cpp
+++ b/src/asterix/DataBlock.cpp
@@ -28,8 +28,8 @@
 
 extern bool gFiltering;
 
-DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp)
-        : m_pCategory(cat), m_nLength(len), m_nTimestamp(nTimestamp), m_bFormatOK(false) {
+DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp, unsigned int nIP)
+        : m_pCategory(cat), m_nLength(len), m_nTimestamp(nTimestamp), m_nIP(nIP), m_bFormatOK(false) {
     const unsigned char *m_pItemDataStart = data;
     long nUnparsed = len;
     int counter = 1;
@@ -40,7 +40,7 @@ DataBlock::DataBlock(Category *cat, unsigned long len, const unsigned char *data
     }
 
     while (nUnparsed > 0) {
-        DataRecord *dr = new DataRecord(cat, counter++, nUnparsed, m_pItemDataStart, nTimestamp);
+        DataRecord *dr = new DataRecord(cat, counter++, nUnparsed, m_pItemDataStart, nTimestamp, nIP);
 
         if (!dr) {
             Tracer::Error("Error DataBlock format.");
@@ -87,6 +87,7 @@ bool DataBlock::getText(std::string &strResult, const unsigned int formatType) {
             strResult += format("\nLen: %ld", m_nLength);
             strResult += format("\nTimestamp: %lf", m_nTimestamp);
             strResult += format("\nHexData: %02X%02X%02X", m_pCategory->m_id, ((m_nLength + 3) >> 8) & 0xff, (m_nLength + 3) & 0xff);
+            strResult += format("\nSrc IP: %lu", m_nIP);
             break;
         case CAsterixFormat::EOut:
             strHeader = format("Asterix.CAT%03d", m_pCategory->m_id);

--- a/src/asterix/DataBlock.h
+++ b/src/asterix/DataBlock.h
@@ -28,7 +28,7 @@
 
 class DataBlock {
 public:
-    DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp = 0.0);
+    DataBlock(Category *cat, unsigned long len, const unsigned char *data, double nTimestamp = 0.0, unsigned int nIP = 0);
 
     virtual
     ~DataBlock();
@@ -36,6 +36,7 @@ public:
     Category *m_pCategory;
     unsigned long m_nLength;
     double m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    unsigned int m_nIP; // source ip when reading GPS files
     bool m_bFormatOK;
 
     std::list<DataRecord *> m_lDataRecords;

--- a/src/asterix/DataRecord.cpp
+++ b/src/asterix/DataRecord.cpp
@@ -177,7 +177,7 @@ bool DataRecord::getText(std::string &strResult, std::string &strHeader, const u
             strNewResult = format("\n-------------------------\nData Record %d", m_nID);
             strNewResult += format("\nLen: %ld", m_nLength);
             strNewResult += format("\nCRC: %08X", m_nCrc);
-            strNewResult += format("\nSRC IP: %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
+            strNewResult += format("\nSource IP: %u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
             strNewResult += format("\nHexData: %s", m_pHexData);
             break;
         case CAsterixFormat::EJSON:

--- a/src/asterix/DataRecord.h
+++ b/src/asterix/DataRecord.h
@@ -28,7 +28,7 @@
 
 class DataRecord {
 public:
-    DataRecord(Category *cat, int id, unsigned long len, const unsigned char *data, double nTimestamp);
+    DataRecord(Category *cat, int id, unsigned long len, const unsigned char *data, double nTimestamp, unsigned int nIP);
 
     virtual
     ~DataRecord();
@@ -39,6 +39,7 @@ public:
     unsigned long m_nFSPECLength;
     unsigned char *m_pFSPECData;
     double m_nTimestamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    unsigned m_nIP; // source ip when reading from GPS
     uint32_t m_nCrc;
     char *m_pHexData; // hexa conversion of data to display
     bool m_bFormatOK;

--- a/src/asterix/InputParser.cpp
+++ b/src/asterix/InputParser.cpp
@@ -35,7 +35,7 @@ InputParser::InputParser(AsterixDefinition *pDefinition)
  * Parse data
  */
 AsterixData *
-InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp) {
+InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp, unsigned int nIP) {
     AsterixData *pAsterixData = new AsterixData();
     unsigned int m_nPos = 0;
     unsigned int m_nDataLength = 0;
@@ -100,7 +100,7 @@ InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferS
             hexString.erase(hexString.size() - 1);
             LOGDEBUG(1, "[%s]\n", hexString.c_str());
 #endif
-            DataBlock *db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp);
+            DataBlock *db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp, nIP);
             m_pData += dataLen;
             m_nPos += dataLen;
             pAsterixData->m_lDataBlocks.push_back(db);
@@ -116,7 +116,7 @@ InputParser::parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferS
 
 DataBlock *
 InputParser::parse_next_data_block(const unsigned char *m_pData, unsigned int &m_nPos, unsigned int m_nBufferSize,
-                                   double nTimestamp, unsigned int &m_nDataLength)
+                                   double nTimestamp, unsigned int nIP, unsigned int &m_nDataLength)
 /*  parse next data block
  *  AUTHOR: Krzysztof Rutkowski, ICM UW, krutk@icm.edu.pl
  */
@@ -170,7 +170,7 @@ InputParser::parse_next_data_block(const unsigned char *m_pData, unsigned int &m
     hexString.erase(hexString.size() - 1);
     LOGDEBUG(1, "[%s]\n", hexString.c_str());
 #endif
-    DataBlock *db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp);
+    DataBlock *db = new DataBlock(m_pDefinition->getCategory(nCategory), dataLen, m_pData, nTimestamp, nIP);
     m_pData += dataLen;
     m_nPos += dataLen;
     m_nDataLength -= dataLen;

--- a/src/asterix/InputParser.h
+++ b/src/asterix/InputParser.h
@@ -38,10 +38,10 @@ public:
 
     ~InputParser() { if (m_pDefinition) delete m_pDefinition; }
 
-    AsterixData *parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp = 0.0);
+    AsterixData *parsePacket(const unsigned char *m_pBuffer, unsigned int m_nBufferSize, double nTimestamp = 0.0, unsigned int nIP = 0);
 
     DataBlock *parse_next_data_block(const unsigned char *m_pData, unsigned int &m_nPos, unsigned int m_nBufferSize,
-                                     double nTimestamp, unsigned int &m_nDataLength);
+                                     double nTimestamp, unsigned int nIP, unsigned int &m_nDataLength);
 
     std::string printDefinition();
 

--- a/src/asterix/asterixformatdescriptor.hxx
+++ b/src/asterix/asterixformatdescriptor.hxx
@@ -51,7 +51,8 @@ public:
             m_pBuffer(NULL),
             m_nBufferSize(0),
             m_nDataSize(0),
-            m_nTimeStamp(0) {
+            m_nTimeStamp(0),
+            m_nIP(0) {
     }
 
     /**
@@ -110,6 +111,19 @@ public:
         m_nTimeStamp = ts;
     }
 
+    void SetIP(unsigned char ip0, unsigned char ip1, unsigned char ip2, unsigned char ip3) {
+        uint32_t v =
+            ((uint32_t)ip0 << 24) |
+            ((uint32_t)ip1 << 16) |
+            ((uint32_t)ip2 <<  8) |
+            ((uint32_t)ip3      );
+        m_nIP = v;
+    }
+
+    unsigned int GetIP() {
+        return m_nIP;
+    }
+
     // used only in PCAP (TODO)
     typedef enum {
         NET_ETHERNET = 0,
@@ -132,6 +146,7 @@ private:
     unsigned int m_nBufferSize; // input buffer size
     unsigned int m_nDataSize; // size of data in buffer
     double m_nTimeStamp; // Date and time when this packet was captured. This value is in seconds since January 1, 1970 00:00:00 GMT
+    uint32_t m_nIP; // src ip of packet
 };
 
 #endif

--- a/src/asterix/asterixformatdescriptor.hxx
+++ b/src/asterix/asterixformatdescriptor.hxx
@@ -120,6 +120,10 @@ public:
         m_nIP = v;
     }
 
+    void SetIP(unsigned int ip) {
+        m_nIP = ip;
+    }
+
     unsigned int GetIP() {
         return m_nIP;
     }

--- a/src/asterix/asterixgpssubformat.cxx
+++ b/src/asterix/asterixgpssubformat.cxx
@@ -172,8 +172,10 @@ bool CAsterixGPSSubformat::ReadPacket(CBaseFormatDescriptor &formatDescriptor, C
                 GPSPost[2], GPSPost[3], GPSPost[4], GPSPost[5], GPSPost[6], GPSPost[7],
                 GPSPost[8], GPSPost[9]);
             LOGDEBUG(1, "GPS Timestamp [%lf]\n", dTimeStamp);
+            LOGDEBUG(1, "SRC IP [%u.%u.%u.%u]\n", GPSPost[3], GPSPost[2], GPSPost[1], GPSPost[0]);
 #endif
             Descriptor.SetTimeStamp(dTimeStamp);
+            Descriptor.SetIP(GPSPost[3], GPSPost[2], GPSPost[1], GPSPost[0]);
 
         }
     }
@@ -252,8 +254,10 @@ bool CAsterixGPSSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
         }
     } else {
         double dTimeStamp = Descriptor.GetTimeStamp();
+	unsigned int nIP = Descriptor.GetIP();
         Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(Descriptor.GetBuffer(),
-                                                                         Descriptor.GetBufferLen(), dTimeStamp);
+                                                                         Descriptor.GetBufferLen(),
+                                                                         dTimeStamp, nIP);
     }
 
     return true;

--- a/src/asterix/asterixrawsubformat.cxx
+++ b/src/asterix/asterixrawsubformat.cxx
@@ -204,7 +204,8 @@ bool CAsterixRawSubformat::ProcessPacket(CBaseFormatDescriptor &formatDescriptor
         }
     } else {
         Descriptor.m_pAsterixData = Descriptor.m_InputParser.parsePacket(Descriptor.GetBuffer(),
-                                                                         Descriptor.GetBufferLen(), dTimestamp);
+                                                                         Descriptor.GetBufferLen(),
+                                                                         dTimestamp, device.getLastSourceIP());
     }
 
     return true;

--- a/src/engine/basedevice.hxx
+++ b/src/engine/basedevice.hxx
@@ -102,6 +102,8 @@ public:
         ResetErrors(true);
     }
 
+    virtual unsigned int getLastSourceIP() { return false; }
+
 protected: // to be used by derived class for error counting
     virtual void CountReadError() {
         _nReadErrors++;

--- a/src/engine/channelfactory.cxx
+++ b/src/engine/channelfactory.cxx
@@ -237,7 +237,7 @@ bool CChannelFactory::ReadPacket() {
         return false;
     }
 
-    // Get thr format descriptor and number
+    // Get the format descriptor and number
     CBaseFormatDescriptor *formatDescriptor = _inputChannel->GetFormatDescriptor();
     if (formatDescriptor == NULL) {
         LOGERROR(1, "ReadPacket() - Cannot get the format descriptor.\n");

--- a/src/engine/udpdevice.cxx
+++ b/src/engine/udpdevice.cxx
@@ -184,7 +184,7 @@ bool CUdpDevice::Read(void *data, size_t *len) {
                      inet_ntoa(_mcastAddr.sin_addr),
                      lenread);
 
-
+            setLastSourceIP(ntohl(clientAddr.sin_addr.s_addr));
             ResetReadErrors(true);
             return true;
         }

--- a/src/engine/udpdevice.hxx
+++ b/src/engine/udpdevice.hxx
@@ -57,7 +57,8 @@ private:
     bool _server;
     struct sockaddr_in _mcastAddr;
     struct in_addr _interfaceAddr;
-    struct in_addr _sourceAddr;
+    struct in_addr _sourceAddr; // from the subscribe command line option
+    uint32_t _nSrcIP; // IP from the recvfrom syscall
     int _port;
     std::vector<int> _socketDesc;
     fd_set _descToRead;
@@ -96,6 +97,9 @@ public:
     virtual unsigned int
     MaxPacketSize() { return MAX_UDP_PACKET_SIZE; } // return maximal packet size (only for packet devices)
     virtual unsigned int BytesLeftToRead() { return 0; } // return number of bytes left to read or 0 if unknown
+
+    unsigned int getLastSourceIP() { return this->_nSrcIP; }
+    void setLastSourceIP(uint32_t nIP) { this->_nSrcIP = nIP; }
 
 private:
     void Init(const char *mcastAddress, const char *interfaceAddress, const char *srcAddress, const int port,


### PR DESCRIPTION
Datablocks coming fron network or from gps files have a source ip associated.

Decoded output doesn't have this information.

This patch adds the capability to export this information in the output (json/text/etc...)